### PR TITLE
Show writing config completion message

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,8 +173,10 @@ class RaceCaptureApp(App):
             self._serial_warning()
 
     def on_write_config_complete(self, result):
+        self.showActivity("Writing completed")
         self.rc_config.stale = False
         Clock.schedule_once(lambda dt: self.configView.dispatch('on_config_written'))
+        Clock.schedule_once(lambda dt: self.showActivity(''), 5)
 
     def on_write_config_error(self, detail):
         alertPopup('Error Writing', 'Could not write configuration:\n\n' + str(detail))


### PR DESCRIPTION
This improves usability a lot. I never quite know if the writing has stuck at the end or has completed.