### PR TITLE
Removed top level 'Race Tracks' menu items and changed cloud download icon

### DIFF
--- a/autosportlabs/racecapture/menu/homepageview.kv
+++ b/autosportlabs/racecapture/menu/homepageview.kv
@@ -41,16 +41,11 @@
 				icon: '\357\203\244'
 				title: 'Dashboard'
 				on_press: root.show_view('dash')
-			DisabledFeatureButton:
-				icon: '\357\202\200'
-				title: 'Analysis'
-				on_press: root.show_view('analysis')				
 			FeatureButton:
 				icon: '\357\202\205'
 				title: 'Configuration'
 				on_press: root.show_view('config')
-			FeatureButton:
-				icon: '\357\200\230'
-				title: 'Race Tracks'
-				on_press: root.show_view('tracks')
-			
+			DisabledFeatureButton:
+				icon: '\357\202\200'
+				title: 'Analysis'
+				on_press: root.show_view('analysis')

--- a/autosportlabs/racecapture/menu/mainmenu.kv
+++ b/autosportlabs/racecapture/menu/mainmenu.kv
@@ -42,12 +42,6 @@
         description: 'Configuration'
         on_main_menu_item_selected: root.on_main_menu_item_selected(*args)		
     MainMenuItem:
-        rcid: 'tracks'
-        size_hint_y: 0.1
-        icon: '\357\200\230'
-        description: 'Race Tracks'
-        on_main_menu_item_selected: root.on_main_menu_item_selected(*args)		
-    MainMenuItem:
         rcid: 'preferences'
         size_hint_y: 0.1
         icon: '\357\200\207'

--- a/autosportlabs/racecapture/views/tracks/tracksview.kv
+++ b/autosportlabs/racecapture/views/tracks/tracksview.kv
@@ -146,11 +146,10 @@
     		halign: 'left'
     	Label:
     		size_hint_x: 0.7
-    	IconButton:
-    		size_hint_x: 0.05
+    	Button:
+    		size_hint_x: 0.20
     		id: updatecheck
-    		disabled: True
-    		text: '\357\203\255'
+    		text: 'Download Tracks'
     		on_press: root.on_update_check()
 							
 <TracksView>:


### PR DESCRIPTION
So there didn't seem to be any reason to have a high-level 'Race Tracks' menu item. It confused me and possibly other users as to how the top level tracks management related to the RCP track configuration. Since the Race Track/Sectors config handles everything on its own (including adding tracks to RCP) this seems simplest.

I also changed the cloud icon to a 'Download Tracks' button, improving usability. Tiny icons that don't look like buttons have no affordances, users won't know what it does or that it's clickable.