### PR TITLE
V1.2.5 channel improvements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,8 @@
 ==1.2.5===
 * OS X support (offically)
 * Additional UI layout improvements for mobile devices
-* allow ctrl-v pasting of negative values into float/integer constrained input fields
-
+* Allow ctrl-v pasting of negative values into float/integer constrained input fields
+* Add ability to customize channel details beyond system defaults (label units, min, max, logging precision)
 ==1.2.4===
 * Usability improvements to Track browser interface for searching and loading
 * Auto-prompt first-time users to download tracks (beginnings of first time setup wizard)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 ==1.2.5===
 * OS X support (offically)
 * Additional UI layout improvements for mobile devices
+* allow ctrl-v pasting of negative values into float/integer constrained input fields
 
 ==1.2.4===
 * Usability improvements to Track browser interface for searching and loading

--- a/autosportlabs/racecapture/data/sampledata.py
+++ b/autosportlabs/racecapture/data/sampledata.py
@@ -130,10 +130,11 @@ class Sample(object):
 
         
 
+UNKNOWN_CHANNEL = ChannelMeta(name='Unknown')
+
 class SystemChannels(EventDispatcher):
     channels = ObjectProperty(None)
     channel_names = []
-    unknownChannel = ChannelMeta(name='Unknown')
     base_dir = None
         
     def __init__(self, **kwargs):
@@ -153,7 +154,7 @@ class SystemChannels(EventDispatcher):
         except Exception as detail:
             print('Error loading system channels: {}'.format(str(detail)))
 
-    def findChannelMeta(self, channel):
+    def findChannelMeta(self, channel, default=UNKNOWN_CHANNEL):
         channelMeta = self.channels.get(channel)
-        if not channelMeta: channelMeta = self.unknownChannel
+        if not channelMeta: channelMeta = default
         return channelMeta

--- a/autosportlabs/racecapture/views/configuration/baseconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/baseconfigview.py
@@ -23,9 +23,8 @@ class BaseChannelView(BoxLayout):
     def on_modified(self, channelConfig):
         pass
     
-    def on_channel(self, instance, value):
+    def on_channel(self, *args):
         if self.channelConfig:
-            self.channelConfig.name = value
             self.channelConfig.stale = True
             self.dispatch('on_modified', self.channelConfig)
 

--- a/autosportlabs/racecapture/views/configuration/channels/channelsview.kv
+++ b/autosportlabs/racecapture/views/configuration/channels/channelsview.kv
@@ -16,12 +16,14 @@
 				spacing: dp(10)
 				FieldLabel:
 					text: 'Name'
-				ValueField:
+				TextValueField:
+				    max_len: 11
 					rcid: 'name'
 					on_text: root.on_name(*args)
 				FieldLabel:
 					text: 'Units'
-				ValueField:
+				TextValueField:
+				    max_len: 7
 					rcid: 'units'
 					on_text: root.on_units(*args)
 		BoxLayout:

--- a/autosportlabs/racecapture/views/configuration/channels/channelsview.kv
+++ b/autosportlabs/racecapture/views/configuration/channels/channelsview.kv
@@ -38,6 +38,8 @@
 					text: 'Precision'
 				IntegerValueField:
 					rcid: 'prec'
+					min_value: 0
+					max_value: 6
 					on_text: root.on_precision(*args)
 				FieldLabel:
 					text: 'Min / max'

--- a/autosportlabs/racecapture/views/configuration/channels/channelsview.kv
+++ b/autosportlabs/racecapture/views/configuration/channels/channelsview.kv
@@ -4,6 +4,7 @@
 <ChannelEditor>:
 	orientation: 'vertical'
 	GridLayout:
+        size_hint_y: 0.75
 		spacing: dp(20)
 		cols: 2
 		BoxLayout:
@@ -51,6 +52,11 @@
 					FloatValueField:
 						rcid: 'max'
 						on_text: root.on_max(*args)
+    IconButton:
+        size_hint_y: 0.25
+        text: "\357\200\214"
+        on_press: root.on_close()
+						
 
 <ChannelLabel>:
 	size_hint_y: None

--- a/autosportlabs/racecapture/views/configuration/channels/channelsview.py
+++ b/autosportlabs/racecapture/views/configuration/channels/channelsview.py
@@ -81,7 +81,10 @@ class ChannelEditor(BoxLayout):
         if self.channel:
             channel = self.channel
             nameField.text = channel.name
-            nameField.disabled = channel.systemChannel
+            try:
+                nameField.disabled = channel.systemChannel
+            except AttributeError:
+                nameField.disabled = False
             unitsField.text = channel.units
             precisionField.text = str(channel.precision)
             minField.text = str(channel.min)

--- a/autosportlabs/racecapture/views/configuration/channels/channelsview.py
+++ b/autosportlabs/racecapture/views/configuration/channels/channelsview.py
@@ -14,6 +14,7 @@ from autosportlabs.racecapture.views.configuration.baseconfigview import BaseCon
 from utils import *
 from autosportlabs.racecapture.config.rcpconfig import *
 from channels import Channels, Channel
+from valuefield import FloatValueField, IntegerValueField, TextValueField
 
 Builder.load_file('autosportlabs/racecapture/views/configuration/channels/channelsview.kv')
 
@@ -80,12 +81,12 @@ class ChannelEditor(BoxLayout):
         
         if self.channel:
             channel = self.channel
-            nameField.text = channel.name
+            nameField.text = str(channel.name)
             try:
                 nameField.disabled = channel.systemChannel
             except AttributeError:
                 nameField.disabled = False
-            unitsField.text = channel.units
+            unitsField.text = str(channel.units)
             precisionField.text = str(channel.precision)
             minField.text = str(channel.min)
             maxField.text = str(channel.max)

--- a/autosportlabs/racecapture/views/configuration/channels/channelsview.py
+++ b/autosportlabs/racecapture/views/configuration/channels/channelsview.py
@@ -64,6 +64,7 @@ class ChannelEditor(BoxLayout):
     def __init__(self, **kwargs):
         super(ChannelEditor, self).__init__(**kwargs)
         self.channel = kwargs.get('channel', None)
+        self.register_event_type('on_channel_edited')        
         self.init_view()
         
     def init_view(self):
@@ -101,10 +102,27 @@ class ChannelEditor(BoxLayout):
         self.channel.precision = int(value)
     
     def on_min(self, instance, value):
-        self.channel.min = float(value)
+        max_range = self.channel.max
+        min_range = float(value)
+        if min_range > max_range:
+            min_range = max_range
+            instance.text = str(min_range)
+        self.channel.min = float(min_range)
     
     def on_max(self, instance, value):
-        self.channel.max = float(value)
+        min_range = self.channel.min
+        max_range = float(value)
+        if max_range < min_range:
+            max_range = min_range
+            instance.text = str(max_range)
+        self.channel.max = float(max_range)
+        
+        
+    def on_channel_edited(self, *args):
+        pass
+    
+    def on_close(self):
+        self.dispatch('on_channel_edited')        
         
 class ChannelsView(BaseConfigView):
     channelsContainer = None

--- a/autosportlabs/racecapture/views/configuration/rcp/analogchannelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/analogchannelsview.py
@@ -71,7 +71,7 @@ class AnalogChannel(BaseChannelView):
                     
     def on_config_updated(self, channelConfig):
         channelSpinner = kvFind(self, 'rcid', 'chanId')
-        channelSpinner.setValue(channelConfig.name)
+        channelSpinner.setValue(channelConfig)
 
         sampleRateSpinner = kvFind(self, 'rcid', 'sr')
         sampleRateSpinner.setValue(channelConfig.sampleRate)

--- a/autosportlabs/racecapture/views/configuration/rcp/gpiochannelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/gpiochannelsview.py
@@ -51,7 +51,7 @@ class GPIOChannel(BaseChannelView):
         sampleRateSpinner.setValue(channelConfig.sampleRate)
     
         channelSpinner = kvFind(self, 'rcid', 'chanId')
-        channelSpinner.setValue(channelConfig.name)
+        channelSpinner.setValue(channelConfig)
         
         modeSpinner = kvFind(self, 'rcid', 'mode')
         modeSpinner.setFromValue(channelConfig.mode)

--- a/autosportlabs/racecapture/views/configuration/rcp/pwmchannelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/pwmchannelsview.py
@@ -78,7 +78,7 @@ class AnalogPulseOutputChannel(BaseChannelView):
                         
     def on_config_updated(self, channelConfig ):
         channelSpinner = kvFind(self, 'rcid', 'chanId')
-        channelSpinner.setValue(channelConfig.name)
+        channelSpinner.setValue(channelConfig)
 
         sampleRateSpinner = kvFind(self, 'rcid', 'sr')
         sampleRateSpinner.setValue(channelConfig.sampleRate)

--- a/autosportlabs/racecapture/views/configuration/rcp/timerchannelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/timerchannelsview.py
@@ -77,7 +77,7 @@ class PulseChannel(BaseChannelView):
         sample_rate_spinner.setValue(channel_config.sampleRate)
     
         channel_spinner = kvFind(self, 'rcid', 'chanId')
-        channel_spinner.setValue(channel_config.name)
+        channel_spinner.setValue(channel_config)
         
         mode_spinner = kvFind(self, 'rcid', 'mode')
         mode_spinner.setFromValue(channel_config.mode)

--- a/channelnameselectorview.kv
+++ b/channelnameselectorview.kv
@@ -5,9 +5,17 @@
         spacing: dp(5)
         orientation: 'horizontal'
         FieldLabel:
+            size_hint_x: 0.5
             text: 'Channel Name'
             halign: 'right'
         ChannelNameSpinner:
+            size_hint_x: 0.4
         	rcid: 'id'
             on_text: root.onSelect(*args)
+        IconButton:
+            size_hint_x: 0.1
+            text: u'\uf013'
+            font_size: self.height * 0.6
+            size_hint_x: 0.1
+            on_release: root.on_customize(*args)
         

--- a/channelnameselectorview.kv
+++ b/channelnameselectorview.kv
@@ -11,7 +11,7 @@
         ChannelNameSpinner:
             size_hint_x: 0.4
         	rcid: 'id'
-            on_text: root.onSelect(*args)
+            on_text: root.on_channel_selected(*args)
         IconButton:
             size_hint_x: 0.1
             text: u'\uf013'

--- a/channelnameselectorview.py
+++ b/channelnameselectorview.py
@@ -10,6 +10,7 @@ Builder.load_file('channelnameselectorview.kv')
 
 class ChannelNameSelectorView(BoxLayout):
     channel_type = NumericProperty(CHANNEL_TYPE_UNKNOWN)
+    channel_config = None
     
     def __init__(self, **kwargs):
         super(ChannelNameSelectorView, self).__init__(**kwargs)
@@ -25,12 +26,16 @@ class ChannelNameSelectorView(BoxLayout):
         spinner.channelType = value
     
     def setValue(self, value):
+        self.channel_config = value
         spinner = kvFind(self, 'rcid', 'id')
-        spinner.text = value
+        spinner.text = str(value.name)
 
     def onSelect(self, instance, value):
         self.dispatch('on_channel', value)
-        
+    
+    def on_customize(self, *args):
+        pass
+    
     def on_channel(self, value):
         pass
         

--- a/channelnameselectorview.py
+++ b/channelnameselectorview.py
@@ -48,12 +48,18 @@ class ChannelNameSelectorView(BoxLayout):
             self.channel_config.precision = channel_meta.precision
             self.dispatch('on_channel')
     
+    def _dismiss_editor(self):
+        self._popup.dismiss()
+        
     def on_customize(self, *args):
+        
+        content = ChannelEditor(channel = self.channel_config)
         popup = Popup(title = 'Customize Channel',
-                      content = ChannelEditor(channel = self.channel_config), 
-                      size_hint=(None, None), size = (dp(500), dp(180)))
-        popup.open()
+                      content = content, 
+                      size_hint=(None, None), size = (dp(500), dp(220)))
         popup.bind(on_dismiss=self.on_edited)
+        content.bind(on_channel_edited=lambda *args:popup.dismiss())                     
+        popup.open()
     
     def on_edited(self, *args):
         self.set_channel_name(self.channel_config.name)

--- a/channelnameselectorview.py
+++ b/channelnameselectorview.py
@@ -49,7 +49,7 @@ class ChannelNameSelectorView(BoxLayout):
             self.dispatch('on_channel')
     
     def on_customize(self, *args):
-        popup = Popup(title = 'Edit Channel',
+        popup = Popup(title = 'Customize Channel',
                       content = ChannelEditor(channel = self.channel_config), 
                       size_hint=(None, None), size = (dp(500), dp(180)))
         popup.open()

--- a/channelnameselectorview.py
+++ b/channelnameselectorview.py
@@ -39,9 +39,9 @@ class ChannelNameSelectorView(BoxLayout):
         spinner.text = str(name)
         
     def on_channel_selected(self, instance, value):
-        channel_meta = self.system_channels.findChannelMeta(value)
+        channel_meta = self.system_channels.findChannelMeta(value, None)
         if channel_meta is not None:
-            self.channel_config.name= channel_meta.name
+            self.channel_config.name = channel_meta.name
             self.channel_config.units = channel_meta.units
             self.channel_config.min = channel_meta.min
             self.channel_config.max = channel_meta.max

--- a/channelnameselectorview.py
+++ b/channelnameselectorview.py
@@ -1,16 +1,20 @@
 import kivy
 from channels import *
 kivy.require('1.8.0')
-from kivy.uix.boxlayout import BoxLayout
 from kivy.app import Builder
+from kivy.metrics import dp
+from kivy.uix.popup import Popup
+from kivy.uix.boxlayout import BoxLayout
 from kivy.properties import NumericProperty
 from utils import *
+from autosportlabs.racecapture.views.configuration.channels.channelsview import ChannelEditor
 
 Builder.load_file('channelnameselectorview.kv')
 
 class ChannelNameSelectorView(BoxLayout):
     channel_type = NumericProperty(CHANNEL_TYPE_UNKNOWN)
     channel_config = None
+    system_channels = None
     
     def __init__(self, **kwargs):
         super(ChannelNameSelectorView, self).__init__(**kwargs)
@@ -19,6 +23,7 @@ class ChannelNameSelectorView(BoxLayout):
         self.bind(channel_type = self.on_channel_type)
 
     def on_channels_updated(self, system_channels):
+        self.system_channels = system_channels
         kvFind(self, 'rcid', 'id').dispatch('on_channels_updated', system_channels)        
     
     def on_channel_type(self, instance, value):
@@ -27,16 +32,34 @@ class ChannelNameSelectorView(BoxLayout):
     
     def setValue(self, value):
         self.channel_config = value
-        spinner = kvFind(self, 'rcid', 'id')
-        spinner.text = str(value.name)
+        self.set_channel_name(value.name)
 
-    def onSelect(self, instance, value):
-        self.dispatch('on_channel', value)
+    def set_channel_name(self, name):
+        spinner = kvFind(self, 'rcid', 'id')
+        spinner.text = str(name)
+        
+    def on_channel_selected(self, instance, value):
+        channel_meta = self.system_channels.findChannelMeta(value)
+        if channel_meta is not None:
+            self.channel_config.name= channel_meta.name
+            self.channel_config.units = channel_meta.units
+            self.channel_config.min = channel_meta.min
+            self.channel_config.max = channel_meta.max
+            self.channel_config.precision = channel_meta.precision
+            self.dispatch('on_channel')
     
     def on_customize(self, *args):
-        pass
+        popup = Popup(title = 'Edit Channel',
+                      content = ChannelEditor(channel = self.channel_config), 
+                      size_hint=(None, None), size = (dp(500), dp(180)))
+        popup.open()
+        popup.bind(on_dismiss=self.on_edited)
     
-    def on_channel(self, value):
+    def on_edited(self, *args):
+        self.set_channel_name(self.channel_config.name)
+        self.dispatch('on_channel')
+        
+    def on_channel(self):
         pass
         
         

--- a/valuefield.py
+++ b/valuefield.py
@@ -1,8 +1,8 @@
 import re
 from kivy.uix.textinput import TextInput
-
+from kivy.properties import NumericProperty
 class ValueField(TextInput):
-
+    
     def __init__(self, *args, **kwargs):
         self.next = kwargs.pop('next', None)
         self.multiline = False
@@ -18,7 +18,15 @@ class ValueField(TextInput):
             self.next.select_all()
         else:
             super(ValueField, self)._keyboard_on_key_down(window, keycode, text, modifiers)
+            
 
+class TextValueField(ValueField):
+    max_len = NumericProperty(100)
+    
+    def insert_text(self, substring, from_undo=False):
+        if len(self.text) < self.max_len:
+            super(TextValueField, self).insert_text(substring, from_undo=from_undo)    
+    
 class IntegerValueField(ValueField):
     pat = re.compile('[^0-9]')
     def insert_text(self, substring, from_undo=False):
@@ -27,7 +35,6 @@ class IntegerValueField(ValueField):
         pat = self.pat
         s = re.sub(pat, '', substring)
         super(IntegerValueField, self).insert_text(s, from_undo=from_undo)
-    
     
 class FloatValueField(ValueField):
     pat = re.compile('[^0-9]')

--- a/valuefield.py
+++ b/valuefield.py
@@ -30,7 +30,7 @@ class TextValueField(ValueField):
 class IntegerValueField(ValueField):
     pat = re.compile('[^0-9]')
     def insert_text(self, substring, from_undo=False):
-        if '-' == substring and not '-' in self.text:
+        if '-'  in substring and not '-' in self.text:
             return super(IntegerValueField, self).insert_text(substring, from_undo=from_undo)
         pat = self.pat
         s = re.sub(pat, '', substring)
@@ -39,7 +39,7 @@ class IntegerValueField(ValueField):
 class FloatValueField(ValueField):
     pat = re.compile('[^0-9]')
     def insert_text(self, substring, from_undo=False):
-        if '-' == substring and not '-' in self.text:
+        if '-' in substring and not '-' in self.text:
             return super(FloatValueField, self).insert_text(substring, from_undo=from_undo)
         pat = self.pat
         if '.' in self.text:

--- a/valuefield.py
+++ b/valuefield.py
@@ -16,6 +16,7 @@ class ValueField(TextInput):
         if key in (9, 13) and self.next is not None:
             self.next.focus = True
             self.next.select_all()
+            self.dispatch('on_text_validate')
         else:
             super(ValueField, self)._keyboard_on_key_down(window, keycode, text, modifiers)
             
@@ -27,17 +28,38 @@ class TextValueField(ValueField):
         if len(self.text) < self.max_len:
             super(TextValueField, self).insert_text(substring, from_undo=from_undo)    
     
-class IntegerValueField(ValueField):
+class NumericValueField(ValueField):
+    min_value = NumericProperty(None, allownone=True)
+    max_value = NumericProperty(None, allownone=True)
+
+    def __init__(self, *args, **kwargs):
+        super(NumericValueField, self).__init__(*args, **kwargs)
+        self.bind(on_text_validate=self.validate_minmax)
+    
+    def validate_minmax(self, *args):
+        try:
+            value = int(self.text)
+            if self.min_value is not None and value < self.min_value:
+                self.text = str(self.min_value)
+            if self.max_value is not None and value > self.max_value:
+                self.text = str(self.max_value)
+        except:
+            pass        
+
+class IntegerValueField(NumericValueField):
     pat = re.compile('[^0-9]')
+        
     def insert_text(self, substring, from_undo=False):
         if '-'  in substring and not '-' in self.text:
             return super(IntegerValueField, self).insert_text(substring, from_undo=from_undo)
-        pat = self.pat
-        s = re.sub(pat, '', substring)
+        
+        s = re.sub(self.pat, '', substring)
         super(IntegerValueField, self).insert_text(s, from_undo=from_undo)
+        
     
-class FloatValueField(ValueField):
+class FloatValueField(NumericValueField):
     pat = re.compile('[^0-9]')
+    
     def insert_text(self, substring, from_undo=False):
         if '-' in substring and not '-' in self.text:
             return super(FloatValueField, self).insert_text(substring, from_undo=from_undo)


### PR DESCRIPTION
This update allows a user to customize a channel on the spot (analog, timer, GPIO or PWM output) beyond what is provided by the system defaults.

still to do, will be in separate PR -  allow custom / modified channels to show up in the list of selectable channels (such as on the dashboard or analysis screens)

