### PR TITLE
V1.3.0 trackmap

### DIFF
--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -519,6 +519,7 @@ CONFIG_SECTOR_COUNT_STAGE = 18
 class Track(object):
     def __init__(self, **kwargs):
         self.stale = False
+        self.trackId = None
         self.trackType = TRACK_TYPE_CIRCUIT
         self.sectorCount = CONFIG_SECTOR_COUNT
         self.startLine = GeoPoint()
@@ -527,6 +528,7 @@ class Track(object):
     
     def fromJson(self, trackJson):
         if trackJson:
+            self.trackId = trackJson.get('id', self.trackId)
             self.trackType = trackJson.get('type', self.trackType)
             sectorsJson = trackJson.get('sec', None)
             del self.sectors[:]
@@ -553,6 +555,7 @@ class Track(object):
     @classmethod
     def fromTrackMap(cls, trackMap):
         t = Track()
+        t.trackId = trackMap.shortId
         t.trackType = TRACK_TYPE_STAGE if trackMap.finishPoint else TRACK_TYPE_CIRCUIT
         t.startLine = copy(trackMap.startFinishPoint)
         t.finishLine = copy(trackMap.finishPoint)
@@ -570,8 +573,9 @@ class Track(object):
         for sector in self.sectors:
             sectors.append(sector.toJson())
         trackJson = {}
-        trackJson['sec']  = sectors
+        trackJson['id'] = self.trackId
         trackJson['type'] = self.trackType
+        trackJson['sec']  = sectors
         
         if self.trackType == TRACK_TYPE_STAGE:
             trackJson['st'] = self.startLine.toJson()

--- a/autosportlabs/racecapture/tracks/trackmanager.py
+++ b/autosportlabs/racecapture/tracks/trackmanager.py
@@ -11,6 +11,7 @@ import urllib2
 import os
 import traceback
 from autosportlabs.racecapture.geo.geopoint import GeoPoint, Region
+from kivy.logger import Logger
         
 class Venue:
     venueId = None
@@ -159,7 +160,7 @@ class TrackManager:
                     region.fromJson(regionNode)
                     self.regions.append(region)
         except Exception as detail:
-            print('Error loading regions data ' + traceback.format_exc())
+            Logger.warning('TrackManager: Error loading regions data ' + traceback.format_exc())
     
     def getAllTrackIds(self):
         return self.tracks.keys()
@@ -224,9 +225,9 @@ class TrackManager:
                 j = json.loads(jsonStr)
                 return j
             except Exception as detail:
-                print('Failed to read: from {} : {}'.format(uri, traceback.format_exc()))
+                Logger.warning('TrackManager: Failed to read: from {} : {}'.format(uri, traceback.format_exc()))
                 if retries < self.readRetries:
-                    print('retrying in ' + str(self.retryDelay) + ' seconds...')
+                    Logger.warning('TrackManager: retrying in ' + str(self.retryDelay) + ' seconds...')
                     retries += 1
                     time.sleep(self.retryDelay)
         raise Exception('Error reading json doc from: ' + uri)    
@@ -253,12 +254,12 @@ class TrackManager:
                                 
                 nextUri = venuesDocJson.get('nextURI')
             except Exception as detail:
-                print('Malformed venue JSON from url ' + nextUri + '; json =  ' + str(venueJson) + ' ' + str(detail))
+                Logger.error('TrackManager: Malformed venue JSON from url ' + nextUri + '; json =  ' + str(venueJson) + ' ' + str(detail))
                 
         retrievedVenueCount = len(trackList)
-        print('fetched list of ' + str(retrievedVenueCount) + ' tracks')                 
+        Logger.info('TrackManager: fetched list of ' + str(retrievedVenueCount) + ' tracks')                 
         if (not totalVenues == retrievedVenueCount):
-            print('Warning - track list count does not reflect downloaded track list size ' + str(totalVenues) + '/' + str(retrievedVenueCount))
+            Logger.warning('TrackManager: track list count does not reflect downloaded track list size ' + str(totalVenues) + '/' + str(retrievedVenueCount))
         return trackList
         
     def downloadTrack(self, venueId):
@@ -314,7 +315,7 @@ class TrackManager:
                     if progressCallback:
                         progressCallback(count, trackCount, trackMap.name)
                 except Exception as detail:
-                    print('failed to read track file ' + trackPath + ';\n' + str(detail))
+                    Logger.warning('TrackManager: failed to read track file ' + trackPath + ';\n' + str(detail))
             del self.trackIdsInRegion[:]
             self.trackIdsInRegion.extend(self.tracks.keys())
                         
@@ -345,10 +346,10 @@ class TrackManager:
                 updateTrack = False
                 count += 1
                 if currentTracks.get(trackId) == None:
-                    print('new track detected ' + trackId)
+                    Logger.info('TrackManager: new track detected ' + trackId)
                     updateTrack = True
                 elif not currentTracks[trackId].updatedAt == updatedTrackList[trackId].updatedAt:
-                    print('existing map changed ' + trackId)
+                    Logger.info('TrackManager: existing map changed ' + trackId)
                     updateTrack = True
                 if updateTrack:
                     updatedTrackMap = self.downloadTrack(trackId)

--- a/autosportlabs/racecapture/tracks/trackmanager.py
+++ b/autosportlabs/racecapture/tracks/trackmanager.py
@@ -85,6 +85,8 @@ class TrackMap:
                 for point in sectorNode:
                     sectorPoints.append(GeoPoint.fromPoint(point[0], point[1]))
             self.sectorPoints = sectorPoints
+            if not self.shortId > 0:
+                raise Exception("Could not parse trackMap: shortId is invalid") 
     
     def toJson(self):
         venueJson = {}
@@ -301,7 +303,6 @@ class TrackManager:
                     trackJson = json.load(json_data)
                     trackMap = TrackMap()
                     trackMap.fromJson(trackJson)
-                    
                     venueNode = trackJson['venue']
                     if venueNode:
                         venue = Venue()

--- a/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
@@ -153,15 +153,12 @@ class AutomaticTrackConfigScreen(Screen):
         trackSelectionPopup.bind(on_tracks_selected=self.on_tracks_selected)
         popup.open()
         self.trackSelectionPopup = popup
-        
     
     def init_tracks_list(self):
         if self.trackManager and self.trackDb:
             matchedTracks = []
             for track in self.trackDb.tracks:
-                startPoint = track.startLine
-                radius = startPoint.metersToDegrees(self.searchRadiusMeters, self.searchBearing)
-                matchedTrack = self.trackManager.findNearbyTrack(track.startLine, radius)
+                matchedTrack = self.trackManager.findTrackByShortId(track.trackId)
                 if matchedTrack:
                     matchedTracks.append(matchedTrack)
                     

--- a/autosportlabs/racecapture/views/tracks/tracksview.py
+++ b/autosportlabs/racecapture/views/tracks/tracksview.py
@@ -231,7 +231,7 @@ class TracksBrowser(BoxLayout):
 
         self.dismissPopups()
         if trackCount == 0:
-            self.tracksGrid.add_widget(Label(text="No Tracks Found"))
+            self.tracksGrid.add_widget(Label(text="No tracks found - try checking for updates"))
             self.setViewDisabled(False)            
             self.ids.namefilter.focus = True                        
         else:

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-__version__ = "1.2.5"
+__version__ = "1.3.0"
 import sys
 import os
 


### PR DESCRIPTION
This is paired up with firmware PR https://github.com/autosportlabs/RaceCapture-Pro_firmware/pull/26

Trackmaps are now identified with a hard ID. This updates the behavior of the track manager and tracks viewer / selector as well as the API.

Trackmanager also will validate the on-disk trackmaps and if they aren't valid (missing createdAt field) it will not load from disk. An update will pull down new trackmaps.