### PR TITLE
Fix OSX reconnect issue

### DIFF
--- a/autosportlabs/comms/serial/serialconnection.py
+++ b/autosportlabs/comms/serial/serialconnection.py
@@ -18,7 +18,7 @@ class SerialConnection():
         print("getting available ports")
         ports = [x[0] for x in list_ports.comports()]
         ports.sort()
-        filtered_ports = filter(lambda port: not port.startswith('/dev/ttyS'), ports)
+        filtered_ports = filter(lambda port: not port.startswith('/dev/ttyS') and not port.startswith('/dev/cu.Bluetooth-Incoming-Port'), ports)
         return filtered_ports
             
     def isOpen(self):


### PR DESCRIPTION
I don't know why or how, but when OSX iterates over available ports, /dev/cu.Bluetooth-Incoming-Port is somehow talking to RCP for a few seconds. This makes the app think RCP is on /dev/cu.Bluetooth-Incoming-Port and continues to use it. But it stops working after a few seconds, causing the app to fail later on.