### PR TITLE
1.3.1 periodic crash

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 ==1.3.1==
-* Fixed periodic crashing on Windows while connected to RCP
+* Fixed periodic crashing while connected to RCP (Windows version)
+* Laptimes properly show leading zeros for seconds portion
 
 ==1.3.0==
 * Support for 2.8.0 firmware

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+==1.3.1==
+* Fixed periodic crashing on Windows while connected to RCP
+
 ==1.3.0==
 * Support for 2.8.0 firmware
 * Configuration screen performance improvements

--- a/autosportlabs/racecapture/views/status/statusview.py
+++ b/autosportlabs/racecapture/views/status/statusview.py
@@ -128,7 +128,7 @@ class StatusView(Screen):
         self.track_manager = track_manager
         self.rc_api = rc_api
         self.register_event_type('on_tracks_updated')
-        self.rc_api.addListener('status', self._on_status_updated)
+        self.rc_api.addListener('status', Clock.schedule_once(lambda dt: self._on_status_updated))
         self._menu_node = self.ids.menu
         self._menu_node.bind(selected_node=self._on_menu_select)
 


### PR DESCRIPTION
Fix for a periodic crash in windows. Very likely due to the status grid view being updated outside of the UI thread.