### PR TITLE
V1.3.2 lapstats simplification

### DIFF
--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -260,6 +260,7 @@ class LapConfigChannel(BaseChannel):
         return json_dict                
         
 class LapConfig(object):
+    DEFAULT_PREDICTED_TIME_SAMPLE_RATE = 5
     def __init__(self, **kwargs):
         self.stale = False
         self.lapCount = LapConfigChannel()
@@ -267,6 +268,8 @@ class LapConfig(object):
         self.predTime = LapConfigChannel()
         self.sector = LapConfigChannel()
         self.sectorTime = LapConfigChannel()
+        self.elapsedTime = LapConfigChannel()
+        self.currentLap = LapConfigChannel()
 
     def fromJson(self, jsonCfg):
         if jsonCfg:
@@ -290,6 +293,14 @@ class LapConfig(object):
             if sectorTime: 
                 self.sectorTime.fromJson(sectorTime)
             
+            elapsedTime = jsonCfg.get('elapsedTime')
+            if elapsedTime: 
+                self.elapsedTime.fromJson(elapsedTime)
+
+            currentLap = jsonCfg.get('currentLap')
+            if currentLap: 
+                self.currentLap.fromJson(currentLap)
+
             self.stale = False
             
     def toJson(self):
@@ -298,7 +309,9 @@ class LapConfig(object):
                                   'lapTime': self.lapTime.toJson(),
                                   'predTime': self.predTime.toJson(),
                                   'sector': self.sector.toJson(),
-                                  'sectorTime': self.sectorTime.toJson()
+                                  'sectorTime': self.sectorTime.toJson(),
+                                  'elapsedTime': self.elapsedTime.toJson(),
+                                  'currentLap': self.currentLap.toJson()
                                   }
                         }
         return lapCfgJson

--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -271,6 +271,26 @@ class LapConfig(object):
         self.elapsedTime = LapConfigChannel()
         self.currentLap = LapConfigChannel()
 
+    def primary_stats_enabled(self):
+        return (self.lapCount.sampleRate > 0 or 
+            self.lapTime.sampleRate > 0 or 
+            self.sector.sampleRate > 0 or 
+            self.sectorTime.sampleRate > 0 or 
+            self.elapsedTime.sampleRate > 0 or 
+            self.currentLap.sampleRate > 0)
+        
+    def set_primary_stats(self, rate):
+        self.lapCount.sampleRate = rate
+        self.lapTime.sampleRate = rate
+        self.sector.sampleRate = rate
+        self.sectorTime.sampleRate = rate
+        self.elapsedTime.sampleRate = rate
+        self.currentLap.sampleRate = rate
+        self.stale = True
+
+    def predtime_stats_enabled(self):
+        return self.predTime.sampleRate > 0 
+    
     def fromJson(self, jsonCfg):
         if jsonCfg:
             lapCount = jsonCfg.get('lapCount')

--- a/autosportlabs/racecapture/views/configuration/rcp/configview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/configview.py
@@ -188,7 +188,7 @@ class ConfigView(Screen):
 
         defaultNode = attach_node('Race Track/Sectors', None, lambda: TrackConfigView())
         attach_node('GPS', None, lambda: GPSChannelsView())
-        attach_node('Racing Statistics', None, lambda: LapStatsView())        
+        attach_node('Race Timing', None, lambda: LapStatsView())        
         attach_node('Analog Sensors', None, lambda: AnalogChannelsView(channels=runtime_channels))
         attach_node('Pulse/RPM Sensors', None, lambda: PulseChannelsView(channels=runtime_channels))
         attach_node('Digital In/Out', None, lambda: GPIOChannelsView(channels=runtime_channels))

--- a/autosportlabs/racecapture/views/configuration/rcp/configview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/configview.py
@@ -188,7 +188,7 @@ class ConfigView(Screen):
 
         defaultNode = attach_node('Race Track/Sectors', None, lambda: TrackConfigView())
         attach_node('GPS', None, lambda: GPSChannelsView())
-        attach_node('Lap Statistics', None, lambda: LapStatsView())        
+        attach_node('Racing Statistics', None, lambda: LapStatsView())        
         attach_node('Analog Sensors', None, lambda: AnalogChannelsView(channels=runtime_channels))
         attach_node('Pulse/RPM Sensors', None, lambda: PulseChannelsView(channels=runtime_channels))
         attach_node('Digital In/Out', None, lambda: GPIOChannelsView(channels=runtime_channels))

--- a/autosportlabs/racecapture/views/configuration/rcp/gpschannelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/gpschannelsview.py
@@ -12,6 +12,7 @@ GPS_CHANNELS_VIEW_KV = 'autosportlabs/racecapture/views/configuration/rcp/gpscha
             
 class GPSChannelsView(BaseConfigView):
     gpsConfig = None
+    lap_config = None
     
     def __init__(self, **kwargs):
         Builder.load_file(GPS_CHANNELS_VIEW_KV)            
@@ -66,6 +67,8 @@ class GPSChannelsView(BaseConfigView):
             self.gpsConfig.sampleRate = value
             self.gpsConfig.stale = True
             self.dispatch('on_modified')
+            if self.lap_config.primary_stats_enabled():
+                self.lap_config.set_primary_stats(value)
                     
     def on_config_updated(self, rcpCfg):
         gpsConfig = rcpCfg.gpsConfig
@@ -82,4 +85,6 @@ class GPSChannelsView(BaseConfigView):
         self.ids.dop.active = gpsConfig.DOPEnabled
 
         self.gpsConfig = gpsConfig
+        self.lap_config = rcpCfg.lapConfig
+        
         

--- a/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.kv
+++ b/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.kv
@@ -5,19 +5,19 @@
     spacing: dp(20)
     orientation: 'vertical'
 	HSeparator:
-        text: 'Racing Statistics'
+        text: 'Race Timing'
         size_hint_y: 0.05
 		
 	SettingsView:
         size_hint_y: 0.3
         id: lapstats
-        label_text: 'Racing Statistics'
-        help_text: 'Enable Statistics for Circuit and Point to Point racing mode'
+        label_text: 'Race Timing'
+        help_text: 'Enable lap/run timing for Circuit and Point to Point racing mode'
         
     SettingsView:
         size_hint_y: 0.3
         id: predtime
-        label_text: 'Predicted Timer'
+        label_text: 'Predictive Timing'
         help_text: 'Enable the predictive lap timer'
 
     BoxLayout:

--- a/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.kv
+++ b/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.kv
@@ -18,7 +18,7 @@
         size_hint_y: 0.3
         id: predtime
         label_text: 'Predicted Timer'
-        help_text: 'Enable predictive lap times'
+        help_text: 'Enable the predictive lap timer'
 
     BoxLayout:
         size_hint_y: 0.35

--- a/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.kv
+++ b/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.kv
@@ -1,48 +1,24 @@
 #:kivy 1.8.0
 
 <LapStatsView>:
-    padding: [30,30]
+    padding: (dp(10), dp(10))
+    spacing: dp(20)
     orientation: 'vertical'
 	HSeparator:
-		text: 'Lap Statistics'    		
-    GridLayout:
-    	spacing: dp(30)
-    	padding: (dp(10), dp(10))
-        size_hint: (1.0,0.8)
-        cols: 2
-        HSeparatorMinor:
-        	text: 'Channel'
-        HSeparatorMinor:
-        	text: 'Sample Rate'
-        FieldLabel:
-        	halign: 'right'
-            text: 'Lap Count'
-        SampleRateSpinner:
-        	rcid: 'lapCount'
-        	on_text: root.on_lapCount_sample_rate(*args)
-        FieldLabel:
-        	halign: 'right'
-            text: 'Lap Time'
-        SampleRateSpinner:
-        	rcid: 'lapTime'
-        	on_text: root.on_lapTime_sample_rate(*args)
-        FieldLabel:
-        	halign: 'right'
-            text: 'Predicted Time'
-        SampleRateSpinner:
-        	rcid: 'predTime'
-        	on_text: root.on_predTime_sample_rate(*args)
-        FieldLabel:
-        	halign: 'right'
-            text: 'Sector'
-        SampleRateSpinner:
-        	rcid: 'sector'
-        	on_text: root.on_sector_sample_rate(*args)
-        FieldLabel:
-        	halign: 'right'
-            text: 'Sector Time'
-        SampleRateSpinner:
-        	rcid: 'sectorTime'
-        	on_text: root.on_sectorTime_sample_rate(*args)
-    Label:
-        size_hint: (1.0, 0.2)
+        text: 'Racing Statistics'
+        size_hint_y: 0.05
+		
+	SettingsView:
+        size_hint_y: 0.3
+        id: lapstats
+        label_text: 'Racing Statistics'
+        help_text: 'Enable Statistics for Circuit and Point to Point racing mode'
+        
+    SettingsView:
+        size_hint_y: 0.3
+        id: predtime
+        label_text: 'Predicted Timer'
+        help_text: 'Enable predictive lap times'
+
+    BoxLayout:
+        size_hint_y: 0.35

--- a/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.py
@@ -9,51 +9,60 @@ from autosportlabs.racecapture.views.configuration.baseconfigview import BaseCon
 from autosportlabs.racecapture.config.rcpconfig import *
 
 LAPSTATS_VIEW_KV = 'autosportlabs/racecapture/views/configuration/rcp/lapstatsview.kv'
-            
+
 class LapStatsView(BaseConfigView):
     lapConfig = None
+    gps_config = None
     
     def __init__(self, **kwargs):
         Builder.load_file(LAPSTATS_VIEW_KV)            
         super(LapStatsView, self).__init__(**kwargs)
         self.register_event_type('on_config_updated')
-
-    
-    def setLapStatChannel(self, channel, spinner):
-        channel.sampleRate = spinner.getSelectedValue()
-        self.lapConfig.stale = True
+        self.ids.lapstats.bind(on_setting=self.on_lapstats_enabled)
+        self.ids.predtime.bind(on_setting=self.on_predtime_enabled)
+        
+    def on_lapstats_enabled(self, instance, value):
+        lap_cfg = self.lapConfig
+        self._normalize_lap_config(lap_cfg, self.gps_config, value)
+        lap_cfg.stale = True
         self.dispatch('on_modified')
         
-    def on_lapCount_sample_rate(self, instance, value):
-        if self.lapConfig:
-            self.setLapStatChannel(self.lapConfig.lapCount, instance)
+    def on_predtime_enabled(self, instance, value):
+        if value: #force lapstats enabled if we enable prdictive timing
+            self.ids.lapstats.setValue(True)
+        rate = LapConfig.DEFAULT_PREDICTED_TIME_SAMPLE_RATE if value else 0
+        config = self.lapConfig
+        config.predTime.sampleRate = rate
+        config.stale = True
+        self.dispatch('on_modified')
+    
+    def _any_lapstats_enabled(self, lap_config):
+        return (lap_config.lapCount.sampleRate > 0 or 
+            lap_config.lapTime.sampleRate > 0 or 
+            lap_config.sector.sampleRate > 0 or 
+            lap_config.sectorTime.sampleRate > 0 or 
+            lap_config.elapsedTime.sampleRate > 0 or 
+            lap_config.currentLap.sampleRate > 0)
+        
+    def _normalize_lap_config(self, lap_cfg, gps_cfg, lapstats_enabled):
+        gps_sample_rate = gps_cfg.sampleRate
+        rate = gps_sample_rate if lapstats_enabled else 0
+        lap_cfg.lapTime.sampleRate = rate
+        lap_cfg.sector.sampleRate = rate
+        lap_cfg.sectorTime.sampleRate = rate
+        lap_cfg.elapsedTime.sampleRate = rate
+        lap_cfg.currentLap.sampleRate = rate
             
-    def on_lapTime_sample_rate(self, instance, value):
-        if self.lapConfig:
-            self.setLapStatChannel(self.lapConfig.lapTime, instance)
+    def on_config_updated(self, rcp_cfg):
+        lapConfig = rcp_cfg.lapConfig
+        
+        any_lapstats_enabled = self._any_lapstats_enabled(lapConfig)
+        self._normalize_lap_config(lapConfig, rcp_cfg.gpsConfig, any_lapstats_enabled)
+        self.ids.lapstats.setValue(any_lapstats_enabled)
+        
+        if lapConfig.predTime.sampleRate > 0:
+            self.ids.predtime.sampleRate.setValue(True)
             
-    def on_predTime_sample_rate(self, instance, value):
-        if self.lapConfig:
-            self.setLapStatChannel(self.lapConfig.predTime, instance)
-        
-    def on_sector_sample_rate(self, instance, value):
-        if self.lapConfig:
-            self.setLapStatChannel(self.lapConfig.sector, instance)
-        
-    def on_sectorTime_sample_rate(self, instance, value):
-        if self.lapConfig:
-            self.setLapStatChannel(self.lapConfig.sectorTime, instance)
-        
-    def setSampleRateSpinner(self, rcid, sampleRate):
-        kvFind(self, 'rcid', rcid).setFromValue(sampleRate)
-        
-    def on_config_updated(self, rcpCfg):
-        lapConfig = rcpCfg.lapConfig
-        
-        self.setSampleRateSpinner('lapCount', lapConfig.lapCount.sampleRate)
-        self.setSampleRateSpinner('lapTime', lapConfig.lapTime.sampleRate)
-        self.setSampleRateSpinner('predTime', lapConfig.predTime.sampleRate)
-        self.setSampleRateSpinner('sector', lapConfig.sector.sampleRate)                
-        self.setSampleRateSpinner('sectorTime', lapConfig.sectorTime.sampleRate)
-        self.lapConfig = lapConfig        
+        self.lapConfig = lapConfig
+        self.gps_config = rcp_cfg.gpsConfig     
         

--- a/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/lapstatsview.py
@@ -1,3 +1,4 @@
+import traceback
 import kivy
 kivy.require('1.8.0')
 
@@ -5,64 +6,61 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.app import Builder
 from samplerateview import *
 from utils import *
+from settingsview import SettingsSwitch
 from autosportlabs.racecapture.views.configuration.baseconfigview import BaseConfigView
 from autosportlabs.racecapture.config.rcpconfig import *
 
 LAPSTATS_VIEW_KV = 'autosportlabs/racecapture/views/configuration/rcp/lapstatsview.kv'
 
 class LapStatsView(BaseConfigView):
-    lapConfig = None
+    lap_config = None
     gps_config = None
     
     def __init__(self, **kwargs):
         Builder.load_file(LAPSTATS_VIEW_KV)            
         super(LapStatsView, self).__init__(**kwargs)
         self.register_event_type('on_config_updated')
+        self.ids.lapstats.setControl(SettingsSwitch())
         self.ids.lapstats.bind(on_setting=self.on_lapstats_enabled)
+        self.ids.predtime.setControl(SettingsSwitch())
         self.ids.predtime.bind(on_setting=self.on_predtime_enabled)
         
     def on_lapstats_enabled(self, instance, value):
-        lap_cfg = self.lapConfig
-        self._normalize_lap_config(lap_cfg, self.gps_config, value)
-        lap_cfg.stale = True
-        self.dispatch('on_modified')
+        if self.lap_config:
+            lap_cfg = self.lap_config
+            self._normalize_lap_config(lap_cfg, self.gps_config, value)
+            lap_cfg.stale = True
+            self.dispatch('on_modified')
+            if not value:
+                self.ids.predtime.setValue(False)
         
     def on_predtime_enabled(self, instance, value):
-        if value: #force lapstats enabled if we enable prdictive timing
-            self.ids.lapstats.setValue(True)
-        rate = LapConfig.DEFAULT_PREDICTED_TIME_SAMPLE_RATE if value else 0
-        config = self.lapConfig
-        config.predTime.sampleRate = rate
-        config.stale = True
-        self.dispatch('on_modified')
+        if self.lap_config:
+            if value: #force lapstats enabled if we enable prdictive timing
+                self.ids.lapstats.setValue(True)
+            rate = LapConfig.DEFAULT_PREDICTED_TIME_SAMPLE_RATE if value else 0
+            config = self.lap_config
+            config.predTime.sampleRate = rate
+            config.stale = True
+            self.dispatch('on_modified')
     
-    def _any_lapstats_enabled(self, lap_config):
-        return (lap_config.lapCount.sampleRate > 0 or 
-            lap_config.lapTime.sampleRate > 0 or 
-            lap_config.sector.sampleRate > 0 or 
-            lap_config.sectorTime.sampleRate > 0 or 
-            lap_config.elapsedTime.sampleRate > 0 or 
-            lap_config.currentLap.sampleRate > 0)
-        
     def _normalize_lap_config(self, lap_cfg, gps_cfg, lapstats_enabled):
         gps_sample_rate = gps_cfg.sampleRate
         rate = gps_sample_rate if lapstats_enabled else 0
-        lap_cfg.lapTime.sampleRate = rate
-        lap_cfg.sector.sampleRate = rate
-        lap_cfg.sectorTime.sampleRate = rate
-        lap_cfg.elapsedTime.sampleRate = rate
-        lap_cfg.currentLap.sampleRate = rate
+        lap_cfg.set_primary_stats(rate)
             
     def on_config_updated(self, rcp_cfg):
-        lapConfig = rcp_cfg.lapConfig
+        lap_config = rcp_cfg.lapConfig
+        gps_config = rcp_cfg.gpsConfig
         
-        any_lapstats_enabled = self._any_lapstats_enabled(lapConfig)
-        self._normalize_lap_config(lapConfig, rcp_cfg.gpsConfig, any_lapstats_enabled)
-        self.ids.lapstats.setValue(any_lapstats_enabled)
+        primary_stats_enabled = lap_config.primary_stats_enabled()
+        self._normalize_lap_config(lap_config, gps_config, primary_stats_enabled)
+        self.ids.lapstats.setValue(primary_stats_enabled)
         
-        if lapConfig.predTime.sampleRate > 0:
-            self.ids.predtime.sampleRate.setValue(True)
+        if lap_config.predTime.sampleRate > 0:
+            self.ids.predtime.setValue(True)
             
-        self.lapConfig = lapConfig
-        self.gps_config = rcp_cfg.gpsConfig     
+        self.gps_config = rcp_cfg.gpsConfig
+        self.lap_config = lap_config
+                 
         


### PR DESCRIPTION
First cut at simplifying lap stats configuration view (now "Racing Stats") and logic for locking GPS sample rate to stats sample rate. 

Predicted time is handled separately. There's logic to force enabling of racing stats if pred time is enabled and to disable predicted time if lap stats are disabled.

