### PR TITLE
Make left side of menu icon actually work when clicked/tapped

### DIFF
--- a/toolbarview.kv
+++ b/toolbarview.kv
@@ -1,7 +1,7 @@
 <ToolbarView>:
     orientation: 'horizontal'
     BoxLayout:
-		padding: self.height * 0.2, 0
+		padding: self.height * 0.5, 0
 		spacing: self.height * 0.2
     	size_hint_x: 0.1
     	orientation: 'horizontal'

--- a/toolbarview.kv
+++ b/toolbarview.kv
@@ -2,7 +2,7 @@
     orientation: 'horizontal'
     BoxLayout:
 		padding: self.height * 0.5, 0
-		spacing: self.height * 0.2
+		spacing: 0
     	size_hint_x: 0.1
     	orientation: 'horizontal'
 	    IconButton:
@@ -18,7 +18,7 @@
 		    background_down: ''
 	    	text: 'Menu'
 	    	size_hint_x: 0.0
-	    	width: self.height * 2.0
+	    	width: self.height * 2.4
 	    	font_size: self.height * 0.8
 	    	on_release: root.mainMenu()
 	    	


### PR DESCRIPTION
The menu that slides out has a small overlap with the the menu icon, making it appear to not respond when tapped.