### PR TITLE
Send empty track config if no tracks are selected in app

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 ==1.3.2==
 * Simplified lap stats page into 'Race Timing' with code that helps guarantee proper configuration
+* Fixed bug where no tracks are removed from RCP if all tracks are removed in configuration view
 
 ==1.3.1==
 * Fixed periodic crashing while connected to RCP (Windows version)

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -554,7 +554,9 @@ class RcpApi:
                     mode = TRACK_ADD_MODE_IN_PROGRESS if index < trackCount - 1 else TRACK_ADD_MODE_COMPLETE
                     cmdSequence.append(RcpCmd('addTrackDb', self.addTrackDb, trackJson, index, mode))
                     index += 1
-    
+            else:
+                cmdSequence.append(RcpCmd('addTrackDb', self.addTrackDb, [], index, TRACK_ADD_MODE_COMPLETE))
+
     def addTrackDb(self, trackJson, index, mode):
         return self.sendCommand({'addTrackDb':
                                  {'index':index, 


### PR DESCRIPTION
This fixes the bug where if you remove all tracks in the config screen in app and save the config to RCP, no tracks are actually removed.