### PR TITLE
V1.3.4 obd2 channel configurability

### DIFF
--- a/autosportlabs/racecapture/views/channels/channelcustomizationview.py
+++ b/autosportlabs/racecapture/views/channels/channelcustomizationview.py
@@ -55,10 +55,15 @@ class ChannelCustomizationView(FloatLayout):
     def setupSlider(self, slider, channelMeta, initialValue):
         min = channelMeta.min
         max = channelMeta.max
+        
         slider.value = initialValue if initialValue != None else min
         slider.min = min
         slider.max = max
         slider.step = (max - min) / 100
+        
+    def sanitize_range(self, channel_range, channel_meta):
+        channel_range.min = channel_meta.min if channel_range.min < channel_meta.min else channel_range.min
+        channel_range.max = channel_meta.max if channel_range.max > channel_meta.max else channel_range.max
         
     def init_view(self):
         channel = self.channel
@@ -70,6 +75,9 @@ class ChannelCustomizationView(FloatLayout):
                     Range(min=channelMeta.max, max=channelMeta.max, color=Range.DEFAULT_WARN_COLOR))
             alertRange = self.settings.userPrefs.get_range_alert(self.getAlertPrefsKey(channel), 
                     Range(min=channelMeta.max, max=channelMeta.max, color=Range.DEFAULT_ALERT_COLOR))
+
+            self.sanitize_range(warnRange, channelMeta)
+            self.sanitize_range(alertRange, channelMeta)
             
             self.setupSlider(self.ids.warnLowSlider, channelMeta, warnRange.min)
             self.setupSlider(self.ids.warnHighSlider, channelMeta, warnRange.max)

--- a/autosportlabs/racecapture/views/configuration/rcp/obd2channelsview.kv
+++ b/autosportlabs/racecapture/views/configuration/rcp/obd2channelsview.kv
@@ -11,10 +11,9 @@
     	text: ''
     	font_size: dp(20)
     	size_hint_x: 0.1    	
-    ChannelNameSpinner:
+    ChannelNameSelectorView:
     	size_hint_x: 0.4
     	id: chan_id
-        on_text: root.on_channel(*args)
     SampleRateSpinner:
     	size_hint_x: 0.4
     	id: sr

--- a/autosportlabs/racecapture/views/configuration/rcp/obd2channelsview.kv
+++ b/autosportlabs/racecapture/views/configuration/rcp/obd2channelsview.kv
@@ -6,13 +6,8 @@
     size_hint_y: None
     height: dp(30)
     orientation: 'horizontal'
-    Label:
-    	id: pidIndex
-    	text: ''
-    	font_size: dp(20)
-    	size_hint_x: 0.1    	
     ChannelNameSelectorView:
-    	size_hint_x: 0.4
+    	size_hint_x: 0.5
     	id: chan_id
     SampleRateSpinner:
     	size_hint_x: 0.4

--- a/autosportlabs/racecapture/views/configuration/rcp/obd2channelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/obd2channelsview.py
@@ -26,16 +26,17 @@ class OBD2Channel(BoxLayout):
         self.max_sample_rate = max_sample_rate
         self.register_event_type('on_delete_pid')
         self.register_event_type('on_modified')
+        self.ids.chan_id.bind(on_channel = self.on_channel)
 
+    def on_channel(self, *args):
+        if self.channel:
+            self.channel.stale = True
+            pid = self.obd2_settings.getPidForChannelName(self.channel.name)
+            self.channel.pidId = pid
+            self.dispatch('on_modified')
+        
     def on_modified(self):
         pass
-
-    def on_channel(self, instance, value):
-        if self.channel:
-            self.channel.name = value
-            pid = self.obd2_settings.getPidForChannelName(value)
-            self.channel.pidId = pid
-            self.dispatch('on_modified')            
 
     def on_sample_rate(self, instance, value):
         if self.channel:
@@ -56,10 +57,10 @@ class OBD2Channel(BoxLayout):
         sample_rate_spinner = self.ids.sr
         sample_rate_spinner.set_max_rate(self.max_sample_rate)        
         sample_rate_spinner.setFromValue(channel.sampleRate)
-        channel_spinner = self.ids.chan_id
-        channel_spinner.filterList = self.obd2_settings.getChannelNames()
-        channel_spinner.on_channels_updated(channels)
-        channel_spinner.text = channel.name
+        channel_editor = self.ids.chan_id
+        channel_editor.filterList = self.obd2_settings.getChannelNames()
+        channel_editor.on_channels_updated(channels)
+        channel_editor.setValue(channel)
                 
 class OBD2ChannelsView(BaseConfigView):
     obd2_cfg = None

--- a/autosportlabs/racecapture/views/configuration/rcp/obd2channelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/obd2channelsview.py
@@ -53,21 +53,22 @@ class OBD2Channel(BoxLayout):
         self.channel = channel
         self.pidIndex = pidIndex
         self.channels = channels
-        self.ids.pidIndex.text = str(pidIndex + 1)
         sample_rate_spinner = self.ids.sr
         sample_rate_spinner.set_max_rate(self.max_sample_rate)        
         sample_rate_spinner.setFromValue(channel.sampleRate)
         channel_editor = self.ids.chan_id
-        channel_editor.filterList = self.obd2_settings.getChannelNames()
+        channel_editor.filter_list = self.obd2_settings.getChannelNames()
         channel_editor.on_channels_updated(channels)
         channel_editor.setValue(channel)
                 
 class OBD2ChannelsView(BaseConfigView):
+    DEFAULT_OBD2_SAMPLE_RATE = 1    
     obd2_cfg = None
     max_sample_rate = 0
     obd2_grid = None
     obd2_settings = None
     base_dir = None
+    
     def __init__(self, **kwargs):
         Builder.load_file(OBD2_CHANNELS_VIEW_KV)
         super(OBD2ChannelsView, self).__init__(**kwargs)
@@ -135,6 +136,7 @@ class OBD2ChannelsView(BaseConfigView):
     def on_add_obd2_channel(self):
         if (self.obd2_cfg):
             pidConfig = PidConfig()
+            pidConfig.sampleRate = self.DEFAULT_OBD2_SAMPLE_RATE
             self.obd2_cfg.pids.append(pidConfig)
             self.add_obd2_channel(len(self.obd2_cfg.pids) - 1, pidConfig, self.max_sample_rate)
             self.update_view_enabled()

--- a/channelnameselectorview.kv
+++ b/channelnameselectorview.kv
@@ -11,7 +11,7 @@
             halign: 'right'
         ChannelNameSpinner:
             size_hint_x: 0.4
-        	rcid: 'id'
+            id: channel_name
             on_text: root.on_channel_selected(*args)
         IconButton:
             size_hint_x: 0.1

--- a/channelnameselectorview.kv
+++ b/channelnameselectorview.kv
@@ -13,9 +13,10 @@
             size_hint_x: 0.4
             id: channel_name
             on_text: root.on_channel_selected(*args)
-        IconButton:
+        BoxLayout:
             size_hint_x: 0.1
-            color: ColorScheme.get_accent()        
-            text: u'\uf013'
-            font_size: self.height * 0.7
-            on_release: root.on_customize(*args)
+            padding: (dp(2), dp(2))
+            IconButton:
+                color: ColorScheme.get_accent()        
+                text: u'\uf013'
+                on_release: root.on_customize(*args)

--- a/channelnameselectorview.py
+++ b/channelnameselectorview.py
@@ -4,7 +4,7 @@ from kivy.app import Builder
 from kivy.metrics import dp
 from kivy.uix.popup import Popup
 from kivy.uix.boxlayout import BoxLayout
-from kivy.properties import NumericProperty
+from kivy.properties import NumericProperty, ListProperty
 from utils import *
 from autosportlabs.racecapture.views.configuration.channels.channelsview import ChannelEditor
 from autosportlabs.racecapture.data.channels import *
@@ -13,6 +13,7 @@ Builder.load_file('channelnameselectorview.kv')
 
 class ChannelNameSelectorView(BoxLayout):
     channel_type = NumericProperty(CHANNEL_TYPE_UNKNOWN)
+    filter_list = ListProperty([])
     channel_config = None
     runtime_channels = None
     
@@ -22,21 +23,22 @@ class ChannelNameSelectorView(BoxLayout):
         self.register_event_type('on_channel')
         self.bind(channel_type = self.on_channel_type)
 
+    def on_filter_list(self, instance, value):
+        self.ids.channel_name.filter_list = value
+        
     def on_channels_updated(self, runtime_channels):
         self.runtime_channels = runtime_channels
-        kvFind(self, 'rcid', 'id').dispatch('on_channels_updated', runtime_channels)        
+        self.ids.channel_name.dispatch('on_channels_updated', runtime_channels)        
     
     def on_channel_type(self, instance, value):
-        spinner = kvFind(self, 'rcid', 'id')
-        spinner.channelType = value
+        self.ids.channel_name.channelType = value
     
     def setValue(self, value):
         self.channel_config = value
         self.set_channel_name(value.name)
 
     def set_channel_name(self, name):
-        spinner = kvFind(self, 'rcid', 'id')
-        spinner.text = str(name)
+        self.ids.channel_name.text = str(name)
         
     def on_channel_selected(self, instance, value):
         channel_meta = self.runtime_channels.findChannelMeta(value, None)

--- a/channelnameselectorview.py
+++ b/channelnameselectorview.py
@@ -24,7 +24,7 @@ class ChannelNameSelectorView(BoxLayout):
         self.bind(channel_type = self.on_channel_type)
 
     def on_filter_list(self, instance, value):
-        self.ids.channel_name.filter_list = value
+        self.ids.channel_name.filterList = value
         
     def on_channels_updated(self, runtime_channels):
         self.runtime_channels = runtime_channels


### PR DESCRIPTION
*Allow the OBD2 channels to pull in defaults for channels that match channel (min / max, etc)
*Allow further customization of channel consistent with other channel editors using ChannelNameSelectorView
*Default sample rate when adding a channel is 1Hz instead of disabled, saving a user step

