### PR TITLE
V1.3.5 auto detect hang

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+==1.3.5==
+* Resolved hanging issue / auto-detect issue typically seen upon USB disconnect / reconnect
+
 ==1.3.4==
 * Sample rate selector for sensor channels reflect capabilities of device
 * Disabled multi-touch on desktop versions, to avoid right click red dot problem

--- a/autosportlabs/comms/comms.py
+++ b/autosportlabs/comms/comms.py
@@ -86,6 +86,7 @@ def connection_message_process(connection, port, rx_queue, tx_queue, command_que
 class Comms():
     CONNECT_TIMEOUT = 1.0    
     DEFAULT_TIMEOUT = 1.0
+    QUEUE_FULL_TIMEOUT = 1.0
     _timeout = DEFAULT_TIMEOUT
     port = None
     _connection = None
@@ -151,5 +152,5 @@ class Comms():
     
     def write_message(self, message):
         if not self.isOpen(): raise Exception('Comms Exception')
-        self._tx_queue.put(message, True, 1.0 )
+        self._tx_queue.put(message, True, Comms.QUEUE_FULL_TIMEOUT )
                     

--- a/autosportlabs/comms/comms.py
+++ b/autosportlabs/comms/comms.py
@@ -3,13 +3,14 @@ import threading
 import multiprocessing
 from Queue import Empty
 from time import sleep
+from kivy.logger import Logger
 
 STAY_ALIVE_TIMEOUT = 4
 COMMAND_CLOSE      = 'CLOSE'
 COMMAND_KEEP_ALIVE = 'PING'
 
 def connection_process_message_reader(rx_queue, connection, should_run):
-    print('connection process message reader started')
+    Logger.info('Comms: connection process message reader started')
     
     while should_run.is_set():
         try:
@@ -17,14 +18,14 @@ def connection_process_message_reader(rx_queue, connection, should_run):
             if msg:
                 rx_queue.put(msg)
         except:
-            print('Exception in connection_process_message_reader')
+            Logger.error('Comms: Exception in connection_process_message_reader')
             traceback.print_exc()
             should_run.clear()
             sleep(0.5)
-    print('connection process message reader exited')            
+    Logger.info('Comms: connection process message reader exited')            
             
 def connection_process_message_writer(tx_queue, connection, should_run):
-    print('connection process message writer started')
+    Logger.info('Comms: connection process message writer started')
     while should_run.is_set():
         try:
             message = tx_queue.get(True, 1.0)
@@ -33,14 +34,14 @@ def connection_process_message_writer(tx_queue, connection, should_run):
         except Empty:
             pass
         except Exception as e:
-            print('Exception in connection_process_message_writer ' + str(e))
+            Logger.error('Comms: Exception in connection_process_message_writer ' + str(e))
             traceback.print_exc()
             should_run.clear()
             sleep(0.5)
-    print('connection process message writer exited')
+    Logger.info('Comms: connection process message writer exited')
     
 def connection_message_process(connection, port, rx_queue, tx_queue, command_queue):
-    print('connection process starting')
+    Logger.info('Comms: connection process starting')
 
     try:    
         connection.open(port) 
@@ -61,12 +62,12 @@ def connection_message_process(connection, port, rx_queue, tx_queue, command_que
             try:
                 command = command_queue.get(True, STAY_ALIVE_TIMEOUT)
                 if command == COMMAND_CLOSE:
-                    print('connection process: got close command')
+                    Logger.info('Comms: got close command')
                     reader_writer_should_run.clear()
             except Empty:
-                print('keep alive timeout')
+                Logger.error('Comms: keep alive timeout')
                 reader_writer_should_run.clear()
-        print('connection worker exiting')
+        Logger.info('Comms: worker exiting')
         
         reader_thread.join()
         writer_thread.join()
@@ -74,12 +75,12 @@ def connection_message_process(connection, port, rx_queue, tx_queue, command_que
         try:
             connection.close()
         except:
-            print('Exception closing connection worker connection')
+            Logger.error('Comms: Exception closing connection worker connection')
     except Exception as e:
-        print("Exception setting up connection process: " + str(type(e)) + str(e))
-        traceback.print_exc()
+        Logger.error("Comms: Exception setting up connection process: " + str(type(e)) + str(e))
+        Logger.debug(traceback.format_exc())
         
-    print('connection worker exited')
+    Logger.info('Comms: connection worker exited')
     
     
 class Comms():
@@ -118,7 +119,7 @@ class Comms():
     
     def open(self):
         connection = self._connection
-        print('Opening connection ' + str(self.port))
+        Logger.info('Comms: Opening connection ' + str(self.port))
         self.start_connection_process()
     
     def keep_alive(self):
@@ -131,15 +132,15 @@ class Comms():
         pass
     
     def close(self):
-        print('comms.close()')
+        Logger.debug('Comms: comms.close()')
         if self.isOpen():
             try:
-                print('closing connection process')
+                Logger.info('Comms: closing connection process')
                 self._command_queue.put_nowait(COMMAND_CLOSE)
                 self._connection_process.join(self._timeout * 2)
-                print('connection process joined')
+                Logger.debug('Comms: connection process joined')
             except:
-                print('Timeout joining connection process')
+                Logger.warning('Comms: Timeout joining connection process')
 
     def read_message(self):
         if not self.isOpen(): raise Exception("Comms Exception")

--- a/autosportlabs/comms/serial/serialconnection.py
+++ b/autosportlabs/comms/serial/serialconnection.py
@@ -2,6 +2,7 @@ import serial
 from serial import SerialException
 from serial.tools import list_ports
 from autosportlabs.comms.commscommon import PortNotOpenException, CommsErrorException
+from kivy.logger import Logger
 
 class SerialConnection():
     DEFAULT_WRITE_TIMEOUT = 1
@@ -15,10 +16,10 @@ class SerialConnection():
         pass
     
     def get_available_ports(self):
-        print("getting available ports")
+        Logger.debug("SerialConnection: getting available ports")
         ports = [x[0] for x in list_ports.comports()]
         ports.sort()
-        filtered_ports = filter(lambda port: not port.startswith('/dev/ttyS') and not port.startswith('/dev/cu.Bluetooth-Incoming-Port'), ports)
+        filtered_ports = filter(lambda port: not port.startswith('/dev/ttyUSB') and not port.startswith('/dev/ttyS') and not port.startswith('/dev/cu.Bluetooth-Incoming-Port'), ports)
         return filtered_ports
             
     def isOpen(self):

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -617,11 +617,7 @@ class RcpApi:
         def on_ver_win(value):
             version_result.version_json = value
             version_result_event.set()
-            
-        def on_ver_fail(value):
-            Logger.info('RCPAPI: on_ver_fail')
-            version_result_event.set()
-        
+                    
         while True:
             try:
                 self._auto_detect_event.wait()

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -9,6 +9,7 @@ from autosportlabs.comms.commscommon import PortNotOpenException, CommsErrorExce
 from functools import partial
 from kivy.clock import Clock
 from kivy.logger import Logger
+from traceback import print_stack
 
 TRACK_ADD_MODE_IN_PROGRESS      = 1
 TRACK_ADD_MODE_COMPLETE         = 2
@@ -162,7 +163,7 @@ class RcpApi:
                                     listener(msgJson)
                                 except Exception as e:
                                     Logger.error('RCPAPI: Message Listener Exception for')
-                                    traceback.print_exc()
+                                    Logger.debug(traceback.format_exc())
                             break
                     msg = ''                        
                 else:
@@ -174,7 +175,7 @@ class RcpApi:
                 sleep(1.0)
             except Exception:
                 Logger.warn('RCPAPI: Message rx worker exception: {} | {}'.format(msg, str(Exception)))
-                traceback.print_exc()
+                Logger.debug(traceback.format_exc())
                 msg = ''
                 error_count += 1
                 if error_count > 5:
@@ -290,7 +291,7 @@ class RcpApi:
                     self.recover_connection()
                 except Exception as detail:
                     Logger.error('RCPAPI: Command sequence exception: ' + str(detail))
-                    traceback.print_exc()
+                    Logger.debug(traceback.format_exc())
                     failCallback(detail)
                     self.recover_connection()
 
@@ -678,8 +679,8 @@ class RcpApi:
                     if self.detect_fail_callback: self.detect_fail_callback()
             except Exception as e:
                 Logger.error('RCPAPI: Error running auto detect: ' + str(e))
-                traceback.print_exc()
+                Logger.debug(traceback.format_exc())
             finally:
                 Logger.info("RCPAPI: auto detect finished. port=" + str(comms.port))
-            sleep(0.1) #back off to prevent auto-detect flooding
+            sleep(1)
 

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -628,7 +628,7 @@ class RcpApi:
                 
                 comms = self.comms
                 if comms and comms.isOpen():
-                    continue  #if we're already open, skip auto-detect
+                    comms.close()
                 
                 version_result = VersionResult()        
                 version_result_event = Event()
@@ -638,8 +638,8 @@ class RcpApi:
                     ports = [comms.port]
                 else:
                     ports = comms.get_available_ports()
+                    Logger.info('RCPAPI: Searching for device on all ports')
         
-                Logger.info('RCPAPI: Searching for device on all ports')
                 testVer = VersionConfig()
                 for p in ports:
                     try:
@@ -681,4 +681,5 @@ class RcpApi:
                 traceback.print_exc()
             finally:
                 Logger.info("RCPAPI: auto detect finished. port=" + str(comms.port))
+            sleep(0.1) #back off to prevent auto-detect flooding
 

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -3,7 +3,7 @@ import json
 import traceback
 import Queue
 from time import sleep
-from threading import Thread, Lock, RLock, Event
+from threading import Thread, RLock, Event
 from autosportlabs.racecapture.config.rcpconfig import *
 from autosportlabs.comms.commscommon import PortNotOpenException, CommsErrorException
 from functools import partial
@@ -20,9 +20,9 @@ SCRIPT_ADD_MODE_COMPLETE        = 2
 DEFAULT_LEVEL2_RETRIES          = 2
 DEFAULT_MSG_RX_TIMEOUT          = 1
 
+AUTODETECT_COOLOFF_TIME         = 1
 AUTODETECT_LEVEL2_RETRIES       = 1
 DEFAULT_READ_RETRIES            = 2
-AUTODETECT_COOLOFF_TIME         = 1
 
 COMMS_KEEP_ALIVE_TIMEOUT        = 2
 

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -22,6 +22,7 @@ DEFAULT_MSG_RX_TIMEOUT          = 1
 
 AUTODETECT_LEVEL2_RETRIES       = 1
 DEFAULT_READ_RETRIES            = 2
+AUTODETECT_COOLOFF_TIME         = 1
 
 COMMS_KEEP_ALIVE_TIMEOUT        = 2
 
@@ -689,5 +690,5 @@ class RcpApi:
                 self._auto_detect_busy.clear()
                 self.removeListener("ver", on_ver_win)
                 self.sendCommandLock.release()
-                sleep(0.1) #back off to prevent auto-detect flooding
+                sleep(AUTODETECT_COOLOFF_TIME)
 

--- a/main.py
+++ b/main.py
@@ -380,8 +380,13 @@ class RaceCaptureApp(App):
                                ))
 
     def rc_detect_fail(self):
+        
+        def re_detect():
+            if not self._rc_api.comms.isOpen():
+                self._rc_api.run_auto_detect()
+                
         self.showStatus("Could not detect RaceCapture/Pro", True)
-        Clock.schedule_once(lambda dt: self._rc_api.run_auto_detect(), 1.0)
+        Clock.schedule_once(lambda dt: re_detect(), 1.0)
 
     def rc_detect_activity(self, info):
         self.showActivity('Searching {}'.format(info))

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 import sys
 import os
 


### PR DESCRIPTION
* make it so only the auto-detect worker can send messages to the API when in auto-detect mode. Prevents other parts of the system from crapping on the auto-detect worker while it's trying to do it's job

* Improve performance of auto-detection- thread synchronizations and preemptive checking of port status prevent multiple detection events to occur even if we've just finished detecting (avoid race conditions)

* Simplified auto-detection message sending and receiving

* Prevent the UI thread from hanging forever in case the command TX queue is full

* improve performance of auto detection in Linux by ignoring ttyUSB* ports

* Cleaned up logging
