### PR TITLE
V1.3.5 dashboard fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+==1.3.5==
+* Improved formatting on tachometer view to allow more space for laptime / delta from best
+* Navigation screen transitions direction matches arrow direction
+* Navigation screen arrows are brighter
+* CurrentLap channel in tachometer dashboard view now actually shows CurrentLap
+
 ==1.3.4==
 * Sample rate selector for sensor channels reflect capabilities of device
 * Disabled multi-touch on desktop versions, to avoid right click red dot problem

--- a/autosportlabs/racecapture/views/dashboard/dashboardview.kv
+++ b/autosportlabs/racecapture/views/dashboard/dashboardview.kv
@@ -8,7 +8,7 @@
 			size_hint_y: 0.10
 			orientation: 'horizontal'
 			IconButton:
-				color: [0.2, 0.2, 0.2, 1.0]
+				color: [1.0, 1.0, 1.0, 1.0]
 				font_size: self.height
 				rcid: 'teleRxStatus'
 				text: ' \357\203\231'
@@ -21,7 +21,7 @@
 			DigitalGauge:
 				rcid: 'right_bottom'
 			IconButton:
-				color: [0.2, 0.2, 0.2, 1.0]
+				color: [1.0, 1.0, 1.0, 1.0]
 				font_size: self.height
 				rcid: 'teleRxStatus'
 				text: '\357\203\232 '

--- a/autosportlabs/racecapture/views/dashboard/dashboardview.py
+++ b/autosportlabs/racecapture/views/dashboard/dashboardview.py
@@ -59,7 +59,6 @@ class DashboardView(Screen):
         comboView = ComboView(name='comboView', dataBus=dataBus, settings=settings)  
         rawChannelView = RawChannelView(name='rawchannelView', dataBus=dataBus, settings=settings)
         
-        #screenMgr.transition=WipeTransition()
         screenMgr.add_widget(gaugeView)
         screenMgr.add_widget(tachView)
         screenMgr.add_widget(laptimeView) 
@@ -81,8 +80,10 @@ class DashboardView(Screen):
         dataBus.start_update()
 
     def on_nav_left(self):
+        self._screen_mgr.transition=SlideTransition(direction='right')        
         self._screen_mgr.current = self._screen_mgr.previous()
 
     def on_nav_right(self):
+        self._screen_mgr.transition=SlideTransition(direction='left')        
         self._screen_mgr.current = self._screen_mgr.next()
         

--- a/autosportlabs/racecapture/views/dashboard/laptimeview.kv
+++ b/autosportlabs/racecapture/views/dashboard/laptimeview.kv
@@ -13,7 +13,7 @@
 				size_hint_x: 0.25
 				BigNumberView:
 					size_hint: (0.6, 0.6)
-					title: 'CurrentLap'
+					channel: 'CurrentLap'
 					warning_color: [0.2, 0.2, 0.2, 1.0]
 					alert_color: [0.2, 0.2, 0.2, 1.0]
 			TimeDelta:

--- a/autosportlabs/racecapture/views/dashboard/tachometerview.kv
+++ b/autosportlabs/racecapture/views/dashboard/tachometerview.kv
@@ -10,12 +10,11 @@
 				size_hint: (0.8, 0.6)
 				orientation: 'horizontal'
 				AnchorLayout:
-					size_hint: (0.3, 1.0)
+					size_hint: (0.25, 1.0)
 					anchor_x: 'center'
 					anchor_y: 'center'
 					BigNumberView:
 						size_hint: (0.65, 0.6)
-						title: 'Lap'
 						channel: 'CurrentLap'
 						warning_color: [0.2, 0.2, 0.2, 1.0]
 						alert_color: [0.2, 0.2, 0.2, 1.0]

--- a/autosportlabs/racecapture/views/dashboard/tachometerview.kv
+++ b/autosportlabs/racecapture/views/dashboard/tachometerview.kv
@@ -14,7 +14,7 @@
 					anchor_x: 'center'
 					anchor_y: 'center'
 					BigNumberView:
-						size_hint: (0.65, 0.6)
+						size_hint: (0.5, 0.6)
 						channel: 'CurrentLap'
 						warning_color: [0.2, 0.2, 0.2, 1.0]
 						alert_color: [0.2, 0.2, 0.2, 1.0]

--- a/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
@@ -18,7 +18,7 @@ from autosportlabs.racecapture.views.channels.channelselectview import ChannelSe
 from autosportlabs.racecapture.views.channels.channelcustomizationview import ChannelCustomizationView
 from autosportlabs.racecapture.views.popup.centeredbubble import CenteredBubble
 from autosportlabs.racecapture.data.channels import *
-
+import traceback
 DEFAULT_NORMAL_COLOR  = [1.0, 1.0 , 1.0, 1.0]
 
 DEFAULT_VALUE = None
@@ -286,7 +286,7 @@ class Gauge(ButtonBehavior, AnchorLayout):
                 self.min = channel_meta.min
                 self.max = channel_meta.max
                 self.precision = channel_meta.precision
-                self.type = channel_meta.type
+                self.type = channel_meta.type if channel_meta.type is not CHANNEL_TYPE_UNKNOWN else self.type
             else:
                 self.min = DEFAULT_MIN
                 self.max = DEFAULT_MAX

--- a/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
@@ -18,7 +18,7 @@ from autosportlabs.racecapture.views.channels.channelselectview import ChannelSe
 from autosportlabs.racecapture.views.channels.channelcustomizationview import ChannelCustomizationView
 from autosportlabs.racecapture.views.popup.centeredbubble import CenteredBubble
 from autosportlabs.racecapture.data.channels import *
-import traceback
+
 DEFAULT_NORMAL_COLOR  = [1.0, 1.0 , 1.0, 1.0]
 
 DEFAULT_VALUE = None


### PR DESCRIPTION
* fixed non-working current lap in tachometer view; 
* channel type was getting munged causing time channels to not be formatted as time
* adjusted spacing on CurrentLap widget to allow more room for laptimes on tachometer view
* direction of screen transition matches direction of arrows
* navigation arrows brighter