### PR TITLE
V1.3.6 loading performance improvements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 ==1.3.6==
 * Make AT&T Alt #1 the primary for AT&T APN settings
 * Improve launch time by lazy-loading main screens
+* Back button / Escape does not drop back to main view if dismissing keyboard or dialog
 
 ==1.3.5==
 * Improved formatting on tachometer view to allow more space for laptime / delta from best

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 ==1.3.6==
 * Make AT&T Alt #1 the primary for AT&T APN settings
+* Improve launch time by lazy-loading main screens
 
 ==1.3.5==
 * Improved formatting on tachometer view to allow more space for laptime / delta from best

--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -637,7 +637,7 @@ class Track(object):
 class TrackConfig(object):
     def __init__(self, **kwargs):
         self.stale=False
-        self.track = None
+        self.track = Track()
         self.radius = 0
         self.autoDetect = 0
         

--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -1,5 +1,6 @@
 from kivy.clock import Clock
 from time import sleep
+from kivy.logger import Logger
 from threading import Thread, Event
 from autosportlabs.racecapture.data.channels import ChannelMeta
 from autosportlabs.racecapture.data.sampledata import Sample, SampleMetaException, ChannelMetaCollection
@@ -182,7 +183,7 @@ class DataBusPump(object):
 
     def _request_meta_handler(self):
             if self._meta_is_stale_counter <= 0:
-                print('Sample Meta is stale, requesting meta')
+                Logger.info('DataBusPump: Sample Meta is stale, requesting meta')
                 self._meta_is_stale_counter = SAMPLES_TO_WAIT_FOR_META
                 self.request_meta()
             else:
@@ -202,12 +203,12 @@ class DataBusPump(object):
         rc_api = self._rc_api
         sample_event = self._sample_event
         
-        print("DataBus Sampler Starting")
+        Logger.info('DataBusPump: DataBus Sampler Starting')
         sample_event.clear()
         if sample_event.wait(SAMPLE_POLL_TEST_TIMEOUT) == True:
-            print('Async sampling detected')
+            Logger.info('DataBusPump: Async sampling detected')
         else:
-            print("Synchronous sampling mode enabled")
+            Logger.info('DataBusPump: Synchronous sampling mode enabled')
             while self._running.is_set():
                 try:
                     #the timeout here is designed to be longer than the streaming rate of 
@@ -219,10 +220,10 @@ class DataBusPump(object):
                     sleep(SAMPLE_POLL_INTERVAL_TIMEOUT)
                 except Exception as e:
                     sleep(SAMPLE_POLL_EXCEPTION_RECOVERY)
-                    print('Exception in sample_worker: ' + str(e))
+                    Logger.error('DataBusPump: Exception in sample_worker: ' + str(e))
                 finally:
                     sample_event.clear()
                 
-        print("DataBus Sampler Exiting")
+        Logger.info('DataBusPump: DataBus Sampler Exiting')
         safe_thread_exit()
 

--- a/autosportlabs/racecapture/status/statuspump.py
+++ b/autosportlabs/racecapture/status/statuspump.py
@@ -1,0 +1,46 @@
+import kivy
+kivy.require('1.8.0')
+from kivy.logger import Logger
+from kivy.clock import Clock
+from time import sleep
+from threading import Thread
+
+
+
+"""Responsible for querying status from the RaceCapture API
+"""
+class StatusPump(object):
+    
+    #how often we query for status
+    STATUS_QUERY_INTERVAL = 2.0
+    
+    #Connection to the RC API
+    _rc_api = None
+    
+    #Things that care about status updates
+    _listeners = []
+    
+    #Worker Thread
+    _status_thread = None
+    
+    def add_listener(self, listener):
+        self._listeners.append(listener)
+                    
+    def start(self, rc_api):
+        Logger.info('StatusPump: starting')
+        self._rc_api = rc_api
+        self._status_thread = Thread(target=self.status_worker)
+        self._status_thread.daemon = True
+        self._status_thread.start()
+        
+    def status_worker(self):
+        self._rc_api.addListener('status', self._on_status_updated)        
+        while True:
+            self._rc_api.get_status()
+            sleep(self.STATUS_QUERY_INTERVAL)
+        
+    def _on_status_updated(self, status):
+        Logger.trace('StatusPump: status updated')
+        for listener in self._listeners:
+            Clock.schedule_once(lambda dt: listener(status))
+        

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -6,7 +6,7 @@ from installfix_garden_graph import Graph, MeshLinePlot
 from autosportlabs.uix.track.racetrackview import RaceTrackView
 from autosportlabs.uix.track.trackmap import TrackMap
 
-Builder.load_file('autosportlabs/racecapture/views/analysis/analysisview.kv')
+ANALYSIS_VIEW_KV = 'autosportlabs/racecapture/views/analysis/analysisview.kv'
 
 class AnalysisView(Screen):
     _settings = None
@@ -14,6 +14,7 @@ class AnalysisView(Screen):
     _trackmanager = None
 
     def __init__(self, **kwargs):
+        Builder.load_file(ANALYSIS_VIEW_KV)
         super(AnalysisView, self).__init__(**kwargs)
         self.register_event_type('on_tracks_updated')
         self._databus = kwargs.get('dataBus')

--- a/autosportlabs/racecapture/views/configuration/rcp/configview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/configview.py
@@ -49,7 +49,6 @@ class LinkedTreeViewLabel(TreeViewLabel):
 
 class ConfigView(Screen):
     #file save/load
-    config = ObjectProperty(None)
     loaded = BooleanProperty(False)
     loadfile = ObjectProperty(None)
     savefile = ObjectProperty(None)
@@ -102,15 +101,12 @@ class ConfigView(Screen):
         self.update_runtime_channels(runtime_channels)
         
     def on_config_updated(self, config):
-        self.config = config
+        self.rc_config = config
         self.update_config_views()        
             
     def on_track_manager(self, instance, value):
         self.update_tracks()
-        
-    def on_config(self, instance, value):
-        self.update_config_views()
-    
+            
     def on_loaded(self, instance, value):
         self.update_config_views()
         self.update_tracks()
@@ -122,7 +118,7 @@ class ConfigView(Screen):
         self.writeStale = False
         
     def update_config_views(self):
-        config = self.config
+        config = self.rc_config
         if config and self.loaded:        
             for view in self.configViews:
                 view.dispatch('on_config_updated', config)
@@ -152,8 +148,8 @@ class ConfigView(Screen):
                     view.bind(on_config_modified=self.on_config_modified)
                     node.view = view
                     if self.loaded:
-                        if self.config:
-                            view.dispatch('on_config_updated', self.config)
+                        if self.rc_config:
+                            view.dispatch('on_config_updated', self.rc_config)
                         if self.track_manager:
                             view.dispatch('on_tracks_updated', self.track_manager)                                    
                 Clock.schedule_once(lambda dt: self.ids.content.add_widget(view))

--- a/autosportlabs/racecapture/views/configuration/rcp/configview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/configview.py
@@ -66,6 +66,7 @@ class ConfigView(Screen):
     _databus = None
     
     def __init__(self, **kwargs):
+        Builder.load_file(CONFIG_VIEW_KV)
         super(ConfigView, self).__init__(**kwargs)
 
         self._databus = kwargs.get('databus')
@@ -125,8 +126,6 @@ class ConfigView(Screen):
         Clock.schedule_once(lambda dt: self._reset_stale())
                 
     def init_screen(self):                
-        Builder.load_file(CONFIG_VIEW_KV)
-        Builder.apply(self)
         self.createConfigViews()
         
     def on_enter(self):

--- a/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
@@ -27,7 +27,7 @@ TRACK_CONFIG_VIEW_KV = 'autosportlabs/racecapture/views/configuration/rcp/trackc
 GPS_STATUS_POLL_INTERVAL = 1.0
 GPS_NOT_LOCKED_COLOR = [0.7, 0.7, 0.0, 1.0]
 GPS_LOCKED_COLOR = [0.0, 1.0, 0.0, 1.0]
-        
+
 class SectorPointView(BoxLayout):
     databus = None
     point = None

--- a/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
@@ -26,7 +26,7 @@ TRACK_CONFIG_VIEW_KV = 'autosportlabs/racecapture/views/configuration/rcp/trackc
 GPS_STATUS_POLL_INTERVAL = 1.0
 GPS_NOT_LOCKED_COLOR = [0.7, 0.7, 0.0, 1.0]
 GPS_LOCKED_COLOR = [0.0, 1.0, 0.0, 1.0]
-
+        
 class SectorPointView(BoxLayout):
     databus = None
     point = None

--- a/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
@@ -367,7 +367,7 @@ class ManualTrackConfigScreen(Screen):
         sectorsContainer = self.sectorsContainer
 
         sectorsContainer.clear_widgets()
-        for i in range(0, trackCfg.track.sectorCount):
+        for i in range(0, len(trackCfg.track.sectors)):
             sectorView = SectorPointView(title = 'Sector ' + str(i), databus=self._databus)
             sectorView.bind(on_config_changed=self.on_config_changed)
             sectorsContainer.add_widget(sectorView)

--- a/autosportlabs/racecapture/views/dashboard/dashboardview.py
+++ b/autosportlabs/racecapture/views/dashboard/dashboardview.py
@@ -12,7 +12,7 @@ from autosportlabs.racecapture.views.dashboard.widgets.tachometer import Tachome
 from utils import kvFind, kvFindClass
 from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge
 
-Builder.load_file('autosportlabs/racecapture/views/dashboard/dashboardview.kv')
+DASHBOARD_VIEW_KV = 'autosportlabs/racecapture/views/dashboard/dashboardview.kv'
 
 class DashboardView(Screen):
     
@@ -26,6 +26,7 @@ class DashboardView(Screen):
     _comboView = None
     
     def __init__(self, **kwargs):
+        Builder.load_file(DASHBOARD_VIEW_KV)
         super(DashboardView, self).__init__(**kwargs)
         self.register_event_type('on_tracks_updated')
         self._databus = kwargs.get('dataBus')

--- a/autosportlabs/racecapture/views/preferences/preferences.py
+++ b/autosportlabs/racecapture/views/preferences/preferences.py
@@ -10,7 +10,7 @@ from kivy.app import Builder
 from utils import *
 import os
 
-Builder.load_file('autosportlabs/racecapture/views/preferences/preferences.kv')
+PREFERENCES_KV_FILE = 'autosportlabs/racecapture/views/preferences/preferences.kv'
 
 class PreferencesView(Screen):
     settings = None
@@ -18,6 +18,7 @@ class PreferencesView(Screen):
     base_dir = None
 
     def __init__(self, settings, **kwargs):
+        Builder.load_file(PREFERENCES_KV_FILE)
         super(PreferencesView, self).__init__(**kwargs)
         self.settings = settings
         self.base_dir = kwargs.get('base_dir')
@@ -27,7 +28,3 @@ class PreferencesView(Screen):
 
         self.content = kvFind(self, 'rcid', 'preferences')
         self.content.add_widget(settings_view)
-        self.register_event_type('on_tracks_updated')
-    
-    def on_tracks_updated(self, track_manager):
-        pass

--- a/autosportlabs/racecapture/views/status/statusview.py
+++ b/autosportlabs/racecapture/views/status/statusview.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 from utils import *
 from fieldlabel import FieldLabel
 
-Builder.load_file('autosportlabs/racecapture/views/status/statusview.kv')
+STATUS_KV_FILE = 'autosportlabs/racecapture/views/status/statusview.kv'
 
 RAW_STATUS_BGCOLOR_1 = [0  , 0  , 0  , 1.0]
 RAW_STATUS_BGCOLOR_2 = [0.10, 0.10, 0.10, 1.0]
@@ -124,6 +124,7 @@ class StatusView(Screen):
     menu_select_color = [1.0,0,0,0.6]
 
     def __init__(self, track_manager, rc_api, **kwargs):
+        Builder.load_file(STATUS_KV_FILE)
         super(StatusView, self).__init__(**kwargs)
         self.track_manager = track_manager
         self.rc_api = rc_api

--- a/autosportlabs/racecapture/views/tracks/tracksview.py
+++ b/autosportlabs/racecapture/views/tracks/tracksview.py
@@ -1,6 +1,6 @@
 import kivy
 kivy.require('1.8.0')
-from kivy.properties import NumericProperty
+from kivy.properties import NumericProperty, ObjectProperty
 from kivy.uix.boxlayout import BoxLayout
 from kivy.clock import Clock
 from kivy.uix.label import Label
@@ -17,7 +17,8 @@ from autosportlabs.uix.track.trackmap import TrackMap
 from autosportlabs.uix.track.racetrackview import RaceTrackView
 from utils import *
 from autosportlabs.racecapture.geo.geopoint import GeoPoint
-Builder.load_file('autosportlabs/racecapture/views/tracks/tracksview.kv')
+
+TRACKS_KV_FILE = 'autosportlabs/racecapture/views/tracks/tracksview.kv'
 
 class SearchInput(TextInput):
     
@@ -111,19 +112,28 @@ class TrackInfoView(BoxLayout):
     
 class TracksView(Screen):
     loaded = False
+    track_manager = ObjectProperty(None)
     
     def __init__(self, **kwargs):
+        Builder.load_file(TRACKS_KV_FILE)
         super(TracksView, self).__init__(**kwargs)
-        self.trackManager = kwargs.get('trackManager')
+        self.track_manager = kwargs.get('track_manager')
         self.register_event_type('on_tracks_updated')
-                
+
+    def init_browser(self):
+        self.ids.browser.set_trackmanager(self.track_manager)
+        self.ids.browser.init_view()
+
+    def on_track_manager(self, instance, value):
+        if value:
+            Clock.schedule_once(lambda dt: self.init_browser())
+
     def on_enter(self):
         if not self.loaded:
-            self.ids.browser.init_view()
             self.loaded = True
             
     def on_tracks_updated(self, track_manager):
-        self.ids.browser.set_trackmanager(track_manager)
+        self.track_manager = track_manager
     
     def check_for_update(self):
         self.ids.browser.on_update_check()

--- a/autosportlabs/racecapture/views/tracks/tracksview.py
+++ b/autosportlabs/racecapture/views/tracks/tracksview.py
@@ -18,7 +18,7 @@ from autosportlabs.uix.track.racetrackview import RaceTrackView
 from utils import *
 from autosportlabs.racecapture.geo.geopoint import GeoPoint
 
-TRACKS_KV_FILE = 'autosportlabs/racecapture/views/tracks/tracksview.kv'
+Builder.load_file('autosportlabs/racecapture/views/tracks/tracksview.kv')
 
 class SearchInput(TextInput):
     
@@ -115,7 +115,6 @@ class TracksView(Screen):
     track_manager = ObjectProperty(None)
     
     def __init__(self, **kwargs):
-        Builder.load_file(TRACKS_KV_FILE)
         super(TracksView, self).__init__(**kwargs)
         self.track_manager = kwargs.get('track_manager')
         self.register_event_type('on_tracks_updated')

--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ class RaceCaptureApp(App):
         self._databus = DataBusFactory().create_standard_databus(self.settings.systemChannels)
         self.settings.runtimeChannels.data_bus = self._databus        
 
-        Window.bind(on_key_down=self._on_keyboard_down)
+        Window.bind(on_keyboard=self._on_keyboard)
         self.register_event_type('on_tracks_updated')
         self.processArgs()
         self.settings.appConfig.setUserDir(self.user_data_dir)
@@ -124,7 +124,7 @@ class RaceCaptureApp(App):
     def on_pause(self):
         return True
     
-    def _on_keyboard_down(self, keyboard, keycode, *args):
+    def _on_keyboard(self, keyboard, keycode, *args):
         if keycode == 27:
             self.switchMainView('home')
 

--- a/main.py
+++ b/main.py
@@ -325,7 +325,7 @@ class RaceCaptureApp(App):
         homepage_view.bind(on_select_view = lambda instance, view_name: self.switchMainView(view_name))
         return homepage_view
 
-    def init_viewbuilders(self):
+    def init_view_builders(self):
         self.view_builders = {'config': self.build_config_view,
                               'tracks': self.build_tracks_view,
                               'dash': self.build_dash_view,
@@ -336,7 +336,7 @@ class RaceCaptureApp(App):
                               }
         
     def build(self):
-        self.init_viewbuilders()
+        self.init_view_builders()
         
         Builder.load_file('racecapture.kv')
         root = self.root

--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ class RaceCaptureApp(App):
     trackManager = None
 
     #Application Status bars
-    statusBar = None
+    status_bar = None
 
     #Main Views
     configView = None
@@ -245,10 +245,10 @@ class RaceCaptureApp(App):
             Clock.schedule_once(lambda dt: self.showMainView(viewKey), 0.25)
 
     def showStatus(self, status, isAlert):
-        self.statusBar.dispatch('on_status', status, isAlert)
+        self.status_bar.dispatch('on_status', status, isAlert)
 
     def showActivity(self, status):
-        self.statusBar.dispatch('on_activity', status)
+        self.status_bar.dispatch('on_activity', status)
 
     def _setX(self, x):
         pass
@@ -265,14 +265,14 @@ class RaceCaptureApp(App):
 
     def build(self):
         Builder.load_file('racecapture.kv')
-        statusBar = kvFind(self.root, 'rcid', 'statusbar')
-        statusBar.bind(on_main_menu=self.on_main_menu)
-        self.statusBar = statusBar
+        root = self.root
+        status_bar = root.ids.status_bar
+        status_bar.bind(on_main_menu=self.on_main_menu)
+        self.status_bar = status_bar
 
-        mainMenu = kvFind(self.root, 'rcid', 'mainMenu')
-        mainMenu.bind(on_main_menu_item=self.on_main_menu_item)
+        root.ids.main_menu.bind(on_main_menu_item=self.on_main_menu_item)
 
-        self.mainNav = kvFind(self.root, 'rcid', 'mainNav')
+        self.mainNav = root.ids.main_nav
 
         #reveal_below_anim
         #reveal_below_simple
@@ -295,9 +295,9 @@ class RaceCaptureApp(App):
 
         rcComms = self._rc_api
         rcComms.addListener('logfile', lambda value: Clock.schedule_once(lambda dt: configView.on_logfile(value)))
-        rcComms.on_progress = lambda value: statusBar.dispatch('on_progress', value)
-        rcComms.on_rx = lambda value: statusBar.dispatch('on_rc_rx', value)
-        rcComms.on_tx = lambda value: statusBar.dispatch('on_rc_tx', value)
+        rcComms.on_progress = lambda value: status_bar.dispatch('on_progress', value)
+        rcComms.on_rx = lambda value: status_bar.dispatch('on_rc_rx', value)
+        rcComms.on_tx = lambda value: status_bar.dispatch('on_rc_tx', value)
 
         status_view = StatusView(
                                  self.trackManager,
@@ -315,7 +315,7 @@ class RaceCaptureApp(App):
         analysisView = AnalysisView(name='analysis', data_bus=self._databus, settings=self.settings)
         preferences_view = PreferencesView(self.settings, name='preferences', base_dir=self.base_dir)
 
-        screenMgr = kvFind(self.root, 'rcid', 'main')
+        screenMgr = root.ids.main
 
         #NoTransition
         #SlideTransition

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 __version__ = "1.3.6"
 import sys
 import os
-import traceback
 
 if __name__ == '__main__' and sys.platform == 'win32':
     from multiprocessing import freeze_support
@@ -210,7 +209,7 @@ class RaceCaptureApp(App):
         self.dataBusPump.meta_is_stale()
         for listener in self.config_listeners:
             Clock.schedule_once(lambda dt: listener.dispatch('on_config_written'))
-        Clock.schedule_once(lambda dt: self.showActivity(''), 1.0)
+        Clock.schedule_once(lambda dt: self.showActivity(''), 5.0)
 
     def on_write_config_error(self, detail):
         alertPopup('Error Writing', 'Could not write configuration:\n\n' + str(detail))

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ if __name__ == '__main__':
 from kivy.app import App, Builder
 from autosportlabs.racecapture.config.rcpconfig import RcpConfig, VersionConfig
 from autosportlabs.racecapture.databus.databus import DataBusFactory, DataBusPump
+from autosportlabs.racecapture.status.statuspump import StatusPump
 from autosportlabs.racecapture.api.rcpapi import RcpApi
 
 class RaceCaptureApp(App):
@@ -76,6 +77,8 @@ class RaceCaptureApp(App):
     #pumps data from rcApi to dataBus. kind of like a bridge
     dataBusPump = DataBusPump()
 
+    _status_pump = StatusPump()
+    
     #Track database manager
     trackManager = None
 
@@ -295,8 +298,7 @@ class RaceCaptureApp(App):
         return config_view
     
     def build_status_view(self):
-        status_view = StatusView(self.trackManager, self._rc_api, name='status')
-        status_view.start_status()
+        status_view = StatusView(self.trackManager, self._status_pump, name='status')
         self.tracks_listeners.append(status_view)
         return status_view
     
@@ -392,6 +394,7 @@ class RaceCaptureApp(App):
         rc_api.detect_fail_callback = self.rc_detect_fail
         rc_api.detect_activity_callback = self.rc_detect_activity
         rc_api.init_comms(comms)
+        self._status_pump.start(rc_api)        
         rc_api.run_auto_detect()
 
     def rc_detect_win(self, version):

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 __version__ = "1.3.6"
 import sys
 import os
+import traceback
 
 if __name__ == '__main__' and sys.platform == 'win32':
     from multiprocessing import freeze_support
@@ -51,6 +52,12 @@ from autosportlabs.racecapture.api.rcpapi import RcpApi
 
 class RaceCaptureApp(App):
 
+    #things that care about configuration being loaded
+    config_listeners = []
+
+    #map of view keys to factory functions for building top level views
+    view_builders = {}
+    
     #container for all settings
     settings = None
 
@@ -72,9 +79,6 @@ class RaceCaptureApp(App):
     #Application Status bars
     status_bar = None
 
-    #Main Views
-    configView = None
-
     #main navigation menu
     mainNav = None
 
@@ -82,7 +86,7 @@ class RaceCaptureApp(App):
     screenMgr = None
 
     #main view references for dispatching notifications
-    mainViews = None
+    mainViews = {}
 
     #application arguments - initialized upon startup
     app_args = []
@@ -197,9 +201,9 @@ class RaceCaptureApp(App):
         self.showActivity("Writing completed")
         self.rc_config.stale = False
         self.dataBusPump.meta_is_stale()
-        Clock.schedule_once(lambda dt: self.configView.dispatch('on_config_written'))
-        Clock.schedule_once(lambda dt: self.showActivity(''), 5)
-        
+        for listener in self.config_listeners:
+            Clock.schedule_once(lambda dt: listener.dispatch('on_config_written'))
+        Clock.schedule_once(lambda dt: self.showActivity(''), 1.0)
 
     def on_write_config_error(self, detail):
         alertPopup('Error Writing', 'Could not write configuration:\n\n' + str(detail))
@@ -214,7 +218,8 @@ class RaceCaptureApp(App):
             self._serial_warning()
 
     def on_read_config_complete(self, rcpCfg):
-        Clock.schedule_once(lambda dt: self.configView.dispatch('on_config_updated', self.rc_config))
+        for listener in self.config_listeners:
+            Clock.schedule_once(lambda dt: listener.dispatch('on_config_updated', self.rc_config))
         self.rc_config.stale = False
         self.showActivity('')
 
@@ -223,7 +228,8 @@ class RaceCaptureApp(App):
 
     def on_tracks_updated(self, track_manager):
         for view in self.mainViews.itervalues():
-            view.dispatch('on_tracks_updated', track_manager)
+            if view is not None:
+                view.dispatch('on_tracks_updated', track_manager)
 
     def notifyTracksUpdated(self):
         self.dispatch('on_tracks_updated', self.trackManager)
@@ -234,15 +240,21 @@ class RaceCaptureApp(App):
     def on_main_menu(self, instance, *args):
         self.mainNav.toggle_state()
 
-    def showMainView(self, viewKey):
+    def showMainView(self, view_name):
         try:
-            self.screenMgr.current = viewKey
+            view = self.mainViews.get(view_name)
+            if not view:
+                view = self.view_builders[view_name]()
+                self.screenMgr.add_widget(view)
+                self.mainViews[view_name] = view
+            self.screenMgr.current = view_name
         except Exception as detail:
-            print('Failed to load main view ' + str(viewKey) + ' ' + str(detail))
+            print('Failed to load main view ' + str(view_name) + ' ' + str(detail))
+            traceback.print_stack()
 
-    def switchMainView(self, viewKey):
+    def switchMainView(self, view_name):
             self.mainNav.anim_to_state('closed')
-            Clock.schedule_once(lambda dt: self.showMainView(viewKey), 0.25)
+            Clock.schedule_once(lambda dt: self.showMainView(view_name), 0.25)
 
     def showStatus(self, status, isAlert):
         self.status_bar.dispatch('on_status', status, isAlert)
@@ -257,15 +269,66 @@ class RaceCaptureApp(App):
         pass
 
     def on_start(self):
-        Clock.schedule_once(lambda dt: self.init_data())
-        Clock.schedule_once(lambda dt: self.init_rc_comms())
-
+        pass
+    
     def on_stop(self):
         self._rc_api.cleanup_comms()
-
+    
+    def build_config_view(self):
+        config_view = ConfigView(name='config',
+                                rcpConfig=self.rc_config,
+                                rc_api=self._rc_api,
+                                databus=self._databus,
+                                settings=self.settings,
+                                base_dir=self.base_dir)
+        config_view.bind(on_read_config=self.on_read_config)
+        config_view.bind(on_write_config=self.on_write_config)
+        config_view.bind(on_run_script=self.on_run_script)
+        config_view.bind(on_poll_logfile=self.on_poll_logfile)
+        config_view.bind(on_set_logfile_level=self.on_set_logfile_level)
+        self._rc_api.addListener('logfile', lambda value: Clock.schedule_once(lambda dt: config_view.on_logfile(value)))
+        self.config_listeners.append(config_view)
+        return config_view
+    
+    def build_status_view(self):
+        status_view = StatusView(
+                                 self.trackManager,
+                                 rc_api,
+                                 name='status')
+        status_view.start_status()
+        return status_view
+    
+    def build_tracks_view(self):
+        tracks_view = TracksView(name='tracks')
+        return tracks_view
+    
+    def build_dash_view(self):
+        dash_view = DashboardView(name='dash', dataBus=self._databus, settings=self.settings)
+        return dash_view
+    
+    def build_analysis_view(self):
+        analysis_view = AnalysisView(name='analysis', data_bus=self._databus, settings=self.settings)
+        return analysis_view
+    
+    def build_preferences_view(self):
+        preferences_view = PreferencesView(name='preferences', settings=self.settings, base_dir=self.base_dir)
+        return preferences_view
+    
+    def init_viewbuilders(self):
+        self.view_builders = {'config': self.build_config_view,
+                              'tracks': self.build_tracks_view,
+                              'dash': self.build_dash_view,
+                              'analysis': self.build_analysis_view,
+                              'preferences': self.build_preferences_view,
+                              'status': self.build_status_view
+                              }
+        
     def build(self):
+        self.init_viewbuilders()
+        
         Builder.load_file('racecapture.kv')
         root = self.root
+        
         status_bar = root.ids.status_bar
         status_bar.bind(on_main_menu=self.on_main_menu)
         self.status_bar = status_bar
@@ -281,42 +344,13 @@ class RaceCaptureApp(App):
         #fade_in
         self.mainNav.anim_type = 'slide_above_anim'
 
-        configView = ConfigView(name='config',
-                                rcpConfig=self.rc_config,
-                                rc_api=self._rc_api,
-                                databus=self._databus,
-                                settings=self.settings,
-                                base_dir=self.base_dir)
-        configView.bind(on_read_config=self.on_read_config)
-        configView.bind(on_write_config=self.on_write_config)
-        configView.bind(on_run_script=self.on_run_script)
-        configView.bind(on_poll_logfile=self.on_poll_logfile)
-        configView.bind(on_set_logfile_level=self.on_set_logfile_level)
+        rc_api = self._rc_api
+        rc_api.on_progress = lambda value: status_bar.dispatch('on_progress', value)
+        rc_api.on_rx = lambda value: status_bar.dispatch('on_rc_rx', value)
+        rc_api.on_tx = lambda value: status_bar.dispatch('on_rc_tx', value)
 
-        rcComms = self._rc_api
-        rcComms.addListener('logfile', lambda value: Clock.schedule_once(lambda dt: configView.on_logfile(value)))
-        rcComms.on_progress = lambda value: status_bar.dispatch('on_progress', value)
-        rcComms.on_rx = lambda value: status_bar.dispatch('on_rc_rx', value)
-        rcComms.on_tx = lambda value: status_bar.dispatch('on_rc_tx', value)
-
-        status_view = StatusView(
-                                 self.trackManager,
-                                 rcComms,
-                                 name='status',
-                                )
-
-        tracksView = TracksView(name='tracks')
-
-        dashView = DashboardView(name='dash', dataBus=self._databus, settings=self.settings)
-
-        homepageView = HomePageView(name='home')
-        homepageView.bind(on_select_view = lambda instance, viewKey: self.switchMainView(viewKey))
-
-        analysisView = AnalysisView(name='analysis', data_bus=self._databus, settings=self.settings)
-        preferences_view = PreferencesView(self.settings, name='preferences', base_dir=self.base_dir)
 
         screenMgr = root.ids.main
-
         #NoTransition
         #SlideTransition
         #SwapTransition
@@ -325,29 +359,19 @@ class RaceCaptureApp(App):
         #FallOutTransition
         #RiseInTransition
         screenMgr.transition=NoTransition()
-
+        homepageView = HomePageView(name='home')
+        homepageView.bind(on_select_view = lambda instance, view_name: self.switchMainView(view_name))
         screenMgr.add_widget(homepageView)
-        screenMgr.add_widget(configView)
-        screenMgr.add_widget(tracksView)
-        screenMgr.add_widget(dashView)
-        screenMgr.add_widget(analysisView)
-        screenMgr.add_widget(preferences_view)
-        screenMgr.add_widget(status_view)
-
-        self.mainViews = {'config' : configView,
-                          'tracks': tracksView,
-                          'dash': dashView,
-                          'analysis': analysisView,
-                          'preferences': preferences_view,
-                          'status': status_view
-                          }
 
         self.screenMgr = screenMgr
-        self.configView = configView
-        self.status_view = status_view
         self.icon = ('resource/images/app_icon_128x128.ico' if sys.platform == 'win32' else 'resource/images/app_icon_128x128.png')
-        self.check_first_time_setup()
+        Clock.schedule_once(lambda dt: self.post_launch(), 1.0)
 
+    def post_launch(self):
+        Clock.schedule_once(lambda dt: self.init_data())
+        Clock.schedule_once(lambda dt: self.init_rc_comms())
+        self.check_first_time_setup()
+        
     def check_first_time_setup(self):
         if self.settings.userPrefs.get_pref('preferences', 'first_time_setup') == 'True':
             Clock.schedule_once(lambda dt: self.first_time_setup(), 0.5)
@@ -366,7 +390,6 @@ class RaceCaptureApp(App):
         if version.is_compatible_version():
             self.showStatus("{} v{}.{}.{}".format(version.friendlyName, version.major, version.minor, version.bugfix), False)
             self.dataBusPump.startDataPump(self._databus, self._rc_api)
-            self.status_view.start_status()
     
             if self.rc_config.loaded == False:
                 Clock.schedule_once(lambda dt: self.on_read_config(self))

--- a/main.py
+++ b/main.py
@@ -282,7 +282,8 @@ class RaceCaptureApp(App):
                                 rc_api=self._rc_api,
                                 databus=self._databus,
                                 settings=self.settings,
-                                base_dir=self.base_dir)
+                                base_dir=self.base_dir,
+                                track_manager=self.trackManager)
         config_view.bind(on_read_config=self.on_read_config)
         config_view.bind(on_write_config=self.on_write_config)
         config_view.bind(on_run_script=self.on_run_script)

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ if __name__ == '__main__':
     from functools import partial
     from kivy.clock import Clock
     from kivy.config import Config
+    from kivy.logger import Logger
     kivy.require('1.8.0')
     Config.set('graphics', 'width', '1024')
     Config.set('graphics', 'height', '576')
@@ -153,7 +154,7 @@ class RaceCaptureApp(App):
         self.settings.userPrefs.set_pref('preferences', 'first_time_setup', False)
         
     def loadCurrentTracksSuccess(self):
-        print('Current Tracks Loaded')
+        Logger.info('RaceCaptureApp: Current Tracks Loaded')
         Clock.schedule_once(lambda dt: self.notifyTracksUpdated())            
 
     def loadCurrentTracksError(self, details):
@@ -188,7 +189,7 @@ class RaceCaptureApp(App):
         self._rc_api.runScript(self.on_run_script_complete, self.on_run_script_error)
 
     def on_run_script_complete(self, result):
-        print('run script complete: ' + str(result))
+        Logger.info('RaceCaptureApp: run script complete: ' + str(result))
 
     def on_run_script_error(self, detail):
         alertPopup('Error Running', 'Error Running Script:\n\n' + str(detail))
@@ -264,16 +265,15 @@ class RaceCaptureApp(App):
         self._rc_api.cleanup_comms()
 
     def showMainView(self, view_name):
-        #try:
-        view = self.mainViews.get(view_name)
-        if not view:
-            view = self.view_builders[view_name]()
-            self.screenMgr.add_widget(view)
-            self.mainViews[view_name] = view
-        self.screenMgr.current = view_name
-        #except Exception as detail:
-         #   print('Failed to load main view ' + str(view_name) + ' ' + str(detail))
-          #  traceback.print_stack()
+        try:
+            view = self.mainViews.get(view_name)
+            if not view:
+                view = self.view_builders[view_name]()
+                self.screenMgr.add_widget(view)
+                self.mainViews[view_name] = view
+            self.screenMgr.current = view_name
+        except Exception as detail:
+            Logger.info('RaceCaptureApp: Failed to load main view ' + str(view_name) + ' ' + str(detail))
 
     def switchMainView(self, view_name):
             self.mainNav.anim_to_state('closed')

--- a/racecapture.kv
+++ b/racecapture.kv
@@ -3,14 +3,14 @@ BoxLayout:
     orientation: 'vertical'
     pos_hint: {'center_x': .5, 'center_y': .5}
     ToolbarView:
-        rcid: 'statusbar'
+        id: status_bar
 
         size_hint: (1.0	, 0.05)
 
     NavigationDrawer:
         size_hint: (1.0, 0.95)
-        rcid: 'mainNav'
+        id: main_nav
         MainMenu:
-            rcid: 'mainMenu'
+            id: main_menu
         ScreenManager:
-            rcid: 'main'
+            id: main


### PR DESCRIPTION
Results in about 2-3 seconds faster load time on my newer phone.

* lazy load main screens to speed up load time
* ESC / back button doesn't do a "double back" if dismissing a dialog
* some clean up of main.py
* factory functions for creating main screens
* do fewer things in build() to speed up load time
* decouple status_view polling into it's own status_pump() object, so status data can be used elsewhere (top status bar, for example)
* make various views work correctly in the context of lazy loading
* PEP8 corrections
* converted to use of Logger in key areas
