### PR TITLE
V1.3.6 dashboard updates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,8 @@
 * Kivy 1.9 support
 * Track map browser performance improvement when showing a large number of results
 * Icon buttons with text to clarify usage and meaning
-
+* New Dasboard Laptime behavior: shows elapsed time on first lap, then flashes last lap time
+  for 5 seconds before returning to displaying predicted time
 ==1.3.5==
 * Improved formatting on tachometer view to allow more space for laptime / delta from best
 * Navigation screen transitions direction matches arrow direction

--- a/autosportlabs/racecapture/views/dashboard/laptimeview.kv
+++ b/autosportlabs/racecapture/views/dashboard/laptimeview.kv
@@ -1,10 +1,9 @@
 <LaptimeView>:
 	BoxLayout:
 		orientation: 'vertical'
-		Laptime:
+		CurrentLaptime:
 			size_hint_y: 0.25
 			rcid: 'curLap'
-			channel: 'CurLapTime'
 			halign: 'center'
 		BoxLayout:
 			size_hint_y: 0.6

--- a/autosportlabs/racecapture/views/dashboard/laptimeview.kv
+++ b/autosportlabs/racecapture/views/dashboard/laptimeview.kv
@@ -1,55 +1,61 @@
 <LaptimeView>:
-	BoxLayout:
-		orientation: 'vertical'
-		CurrentLaptime:
-			size_hint_y: 0.3
-			rcid: 'curLap'
-			halign: 'center'
-			normal_color: [1.0, 1.0 , 1.0, 1.0]
-		BoxLayout:
-			size_hint_y: 0.55
-			orientation: 'horizontal'
-			AnchorLayout:
-				size_hint_x: 0.25
-				BigNumberView:
-					size_hint: (0.8, 0.8)
-					channel: 'CurrentLap'
-					warning_color: [0.2, 0.2, 0.2, 1.0]
-					alert_color: [0.2, 0.2, 0.2, 1.0]
-			TimeDelta:
-				size_hint_x: 0.65
-				size_hint_y: 0.8
-				rcid: 'delta'
-				channel: 'LapDelta'
-				halign: 'right'
-				valign: 'middle'
-			BoxLayout:
-				size_hint_x: 0.1
-		BoxLayout:
-			orientation: 'horizontal'
-			size_hint_y: 0.15
-			spacing: self.height * 0.1
-			FieldLabel:
-				size_hint_x: 0.15
-				font_size: self.height * 0.5
-				halign: 'right'
-				text: 'Best'
-			Laptime:
-				rcid: 'bestLap'
-				channel: 'BestLap'
-				size_hint_x: 0.35
-				halign: 'left'
-				normal_color: [1.0, 0.0 , 1.0, 1.0]
-			Laptime:
-				rcid: 'sector'
-				channel: 'SectorTime'
-				size_hint_x: 0.35
-				halign: 'right'
-				normal_color: [1.0, 1.0 , 0.0, 1.0]
-			FieldLabel:
-				size_hint_x: 0.15
-				font_size: self.height * 0.5
-				halign: 'left'
-				rcid: 'sector'
-				text: 'Sector'
-				
+    BoxLayout:
+        orientation: 'vertical'
+        CurrentLaptime:
+            size_hint_y: 0.3
+            rcid: 'curLap'
+            halign: 'center'
+            normal_color: [1.0, 1.0 , 1.0, 1.0]
+        BoxLayout:
+            size_hint_y: 0.55
+            orientation: 'horizontal'
+            AnchorLayout:
+                size_hint_x: 0.25
+                BigNumberView:
+                    size_hint: (0.8, 0.8)
+                    channel: 'CurrentLap'
+                    warning_color: [0.2, 0.2, 0.2, 1.0]
+                    alert_color: [0.2, 0.2, 0.2, 1.0]
+            BoxLayout:
+                orientation: 'vertical'
+                size_hint_x: 0.65
+                BoxLayout:
+                    size_hint_y: 0.1
+                TimeDelta:
+                    size_hint_y: 0.8
+                    rcid: 'delta'
+                    channel: 'LapDelta'
+                    halign: 'right'
+                    valign: 'middle'
+                BoxLayout:
+                    size_hint_y: 0.1
+            BoxLayout:
+                size_hint_x: 0.1
+        BoxLayout:
+            orientation: 'horizontal'
+            size_hint_y: 0.15
+            spacing: self.height * 0.1
+            FieldLabel:
+                size_hint_x: 0.15
+                font_size: self.height * 0.5
+                halign: 'right'
+                text: 'Best'
+            Laptime:
+                rcid: 'bestLap'
+                channel: 'BestLap'
+                size_hint_x: 0.35
+                halign: 'left'
+                normal_color: [1.0, 0.0 , 1.0, 1.0]
+            Laptime:
+                rcid: 'sector'
+                channel: 'SectorTime'
+                size_hint_x: 0.35
+                halign: 'right'
+                normal_color: [1.0, 1.0 , 0.0, 1.0]
+            FieldLabel:
+                size_hint_x: 0.15
+                font_size: self.height * 0.5
+                halign: 'left'
+                rcid: 'sector'
+                text: 'Sector'
+                

--- a/autosportlabs/racecapture/views/dashboard/laptimeview.kv
+++ b/autosportlabs/racecapture/views/dashboard/laptimeview.kv
@@ -2,24 +2,27 @@
 	BoxLayout:
 		orientation: 'vertical'
 		CurrentLaptime:
-			size_hint_y: 0.25
+			size_hint_y: 0.3
 			rcid: 'curLap'
 			halign: 'center'
+			normal_color: [1.0, 1.0 , 1.0, 1.0]
 		BoxLayout:
-			size_hint_y: 0.6
+			size_hint_y: 0.55
 			orientation: 'horizontal'
 			AnchorLayout:
 				size_hint_x: 0.25
 				BigNumberView:
-					size_hint: (0.6, 0.6)
+					size_hint: (0.8, 0.8)
 					channel: 'CurrentLap'
 					warning_color: [0.2, 0.2, 0.2, 1.0]
 					alert_color: [0.2, 0.2, 0.2, 1.0]
 			TimeDelta:
 				size_hint_x: 0.65
+				size_hint_y: 0.8
 				rcid: 'delta'
 				channel: 'LapDelta'
 				halign: 'right'
+				valign: 'middle'
 			BoxLayout:
 				size_hint_x: 0.1
 		BoxLayout:

--- a/autosportlabs/racecapture/views/dashboard/laptimeview.py
+++ b/autosportlabs/racecapture/views/dashboard/laptimeview.py
@@ -5,7 +5,7 @@ from kivy.app import Builder
 from kivy.uix.screenmanager import Screen
 from utils import kvFind, kvFindClass
 from autosportlabs.racecapture.views.dashboard.widgets.laptime import Laptime
-from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge
+from autosportlabs.racecapture.views.dashboard.widgets.gauge import SingleChannelGauge, Gauge
 Builder.load_file('autosportlabs/racecapture/views/dashboard/laptimeview.kv')
 
 class LaptimeView(Screen):
@@ -20,7 +20,7 @@ class LaptimeView(Screen):
         self.initScreen()
         
     def on_meta(self, channelMetas):
-        gauges = self.findActiveGauges()
+        gauges = self.findActiveGauges(SingleChannelGauge)
         
         for gauge in gauges:
             channel = gauge.channel
@@ -31,15 +31,15 @@ class LaptimeView(Screen):
                     gauge.min = channelMeta.min
                     gauge.max = channelMeta.max
 
-    def findActiveGauges(self):
-        return list(kvFindClass(self, Gauge))
+    def findActiveGauges(self, gauge_type):
+        return list(kvFindClass(self, gauge_type))
         
     def initScreen(self):
         dataBus = self._databus
         settings = self._settings
         dataBus.addMetaListener(self.on_meta)
         
-        gauges = self.findActiveGauges()
+        gauges = self.findActiveGauges(Gauge)
         for gauge in gauges:
             gauge.settings = settings
             gauge.data_bus = dataBus

--- a/autosportlabs/racecapture/views/dashboard/tachometerview.kv
+++ b/autosportlabs/racecapture/views/dashboard/tachometerview.kv
@@ -14,7 +14,7 @@
 					anchor_x: 'center'
 					anchor_y: 'center'
 					BigNumberView:
-						size_hint: (0.5, 0.6)
+						size_hint: (0.8, 0.8)
 						channel: 'CurrentLap'
 						warning_color: [0.2, 0.2, 0.2, 1.0]
 						alert_color: [0.2, 0.2, 0.2, 1.0]
@@ -23,14 +23,18 @@
 					orientation: 'vertical'
 					CurrentLaptime:
 						rcid: 'curLap'
-						halign: 'left'
+                        normal_color: [1.0, 1.0 , 1.0, 1.0]						
 					BoxLayout:
 						orientation: 'horizontal'
 						TimeDelta:
 							rcid: 'delta'
 							channel: 'LapDelta'
-							halign: 'left'
+							halign: 'right'
+							valign: 'middle'
 							value: None
+							size_hint_x: 0.8
+						BoxLayout:
+                            size_hint_x: 0.2
 		AnchorLayout:
 			anchor_x: 'left'
 			anchor_y: 'center'

--- a/autosportlabs/racecapture/views/dashboard/tachometerview.kv
+++ b/autosportlabs/racecapture/views/dashboard/tachometerview.kv
@@ -28,24 +28,10 @@
 					BoxLayout:
 						orientation: 'horizontal'
 						TimeDelta:
-							size_hint_x: 0.50
 							rcid: 'delta'
 							channel: 'LapDelta'
 							halign: 'left'
 							value: None
-						BoxLayout:
-							size_hint_x: 0.50
-							orientation: 'vertical'
-							Widget:
-								size_hint_y: 0.25
-							Laptime:
-								size_hint_y: 0.50
-								rcid: 'bestLap'
-								channel: 'BestLap'
-								halign: 'center'
-								normal_color: [1.0, 0.0 , 1.0, 1.0]
-							Widget:
-								size_hint_y: 0.25
 		AnchorLayout:
 			anchor_x: 'left'
 			anchor_y: 'center'

--- a/autosportlabs/racecapture/views/dashboard/tachometerview.kv
+++ b/autosportlabs/racecapture/views/dashboard/tachometerview.kv
@@ -21,9 +21,8 @@
 				BoxLayout:
 					size_hint: (0.7, 1.0)
 					orientation: 'vertical'
-					Laptime:
+					CurrentLaptime:
 						rcid: 'curLap'
-						channel: 'CurLapTime'
 						halign: 'left'
 					BoxLayout:
 						orientation: 'horizontal'

--- a/autosportlabs/racecapture/views/dashboard/widgets/bignumberview.kv
+++ b/autosportlabs/racecapture/views/dashboard/widgets/bignumberview.kv
@@ -8,7 +8,7 @@
 	    Label:
 	    	id: value
 	    	color: root.title_color
-	    	size_hint_y: 0.85
+	    	size_hint_y: 0.8
 	    	on_texture: root.change_font_size()
 	    	font_size: self.height
 	    	font_name: "resource/fonts/ASL_light.ttf"
@@ -16,6 +16,8 @@
 	    	id: title
 			font_name: "resource/fonts/ASL_light.ttf"
 	    	color: root.title_color
-	    	size_hint_y: 0.15
+	    	size_hint_y: 0.1
 	    	font_size: self.height
 	    	text: root.title
+	    BoxLayout:
+            size_hint_y: 0.1

--- a/autosportlabs/racecapture/views/dashboard/widgets/bignumberview.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/bignumberview.py
@@ -10,14 +10,14 @@ from utils import kvFind
 from iconbutton import TileIconButton
 from kivy.clock import Clock
 from kivy.properties import StringProperty, NumericProperty, ObjectProperty
-from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge
+from autosportlabs.racecapture.views.dashboard.widgets.gauge import CustomizableGauge
 Builder.load_file('autosportlabs/racecapture/views/dashboard/widgets/bignumberview.kv')
 
 DEFAULT_NORMAL_COLOR  = [0.2, 0.2 , 0.2, 1.0]
 DEFAULT_VALUE_FONT_SIZE = sp(180)
 DEFAULT_TITLE_FONT_SIZE = sp(25)
 
-class BigNumberView(Gauge):
+class BigNumberView(CustomizableGauge):
 
     _backgroundView  = None
     title_font_size = NumericProperty(DEFAULT_TITLE_FONT_SIZE)

--- a/autosportlabs/racecapture/views/dashboard/widgets/digitalgauge.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/digitalgauge.py
@@ -5,13 +5,13 @@ from kivy.app import Builder
 from kivy.metrics import dp
 from utils import kvFind, kvquery
 from kivy.properties import NumericProperty, ObjectProperty
-from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge
+from autosportlabs.racecapture.views.dashboard.widgets.gauge import CustomizableGauge
 
 Builder.load_file('autosportlabs/racecapture/views/dashboard/widgets/digitalgauge.kv')
 
 DEFAULT_BACKGROUND_COLOR = [0, 0, 0, 0]
 
-class DigitalGauge(Gauge):
+class DigitalGauge(CustomizableGauge):
 
     alert_background_color = ObjectProperty(DEFAULT_BACKGROUND_COLOR)        
     

--- a/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
@@ -47,13 +47,14 @@ class CustomizeGaugeBubble(CenteredBubble):
 NULL_LAP_TIME='--:--.---'
 
 class Gauge(AnchorLayout):
-    _valueView = None
+    rcid = None
     settings = ObjectProperty(None)    
     value_size = NumericProperty(0)
     title_size = NumericProperty(0)
     title = StringProperty('')
     data_bus = ObjectProperty(None)
-    rcid = None
+    title_color   = ObjectProperty(DEFAULT_NORMAL_COLOR)
+    normal_color  = ObjectProperty(DEFAULT_NORMAL_COLOR)
     
     def __init__(self, **kwargs):
         super(Gauge, self).__init__(**kwargs)
@@ -62,15 +63,8 @@ class Gauge(AnchorLayout):
         self.settings = kwargs.get('settings', self.settings)
 
     @property
-    def valueView(self):
-        if not self._valueView:
-            self._valueView = self.ids.value
-        return self._valueView
-
-    @property
     def titleView(self):
         return self.ids.title
-        
 
     def on_title(self, instance, value):
         try:
@@ -100,20 +94,36 @@ class Gauge(AnchorLayout):
             Logger.error('Gauge: Failed to update gauge title & units ' + str(e) + ' ' + str(title))
             traceback.print_exc()
                  
+    def on_channel_meta(self, channel_metas):
+        pass
+    
 class SingleChannelGauge(Gauge):
+    _valueView = None    
     channel = StringProperty(None, allownone=True)    
     value = NumericProperty(None, allownone=True)
     sensor_format = "{:.0f}"
     value_formatter = None
     precision = NumericProperty(DEFAULT_PRECISION)
     type = NumericProperty(DEFAULT_TYPE)
-    title_color   = ObjectProperty(DEFAULT_NORMAL_COLOR)
-    normal_color  = ObjectProperty(DEFAULT_NORMAL_COLOR)
+    halign = StringProperty(None)
+    valign = StringProperty(None)
 
     def __init__(self, **kwargs):
         super(SingleChannelGauge, self).__init__(**kwargs)
         self.channel = kwargs.get('targetchannel', self.channel)
         self.value_formatter = self.sensor_formatter        
+
+    @property
+    def valueView(self):
+        if not self._valueView:
+            self._valueView = self.ids.value
+        return self._valueView
+
+    def on_halign(self, instance, value):
+        self.valueView.halign = value 
+
+    def on_valign(self, instance, value):
+        self.valueView.valign = value 
 
     def on_channel_meta(self, channel_metas):
         channel = self.channel
@@ -144,6 +154,11 @@ class SingleChannelGauge(Gauge):
     def on_data_bus(self, instance, value):
         self._update_channel_binding()
     
+    def updateColors(self):
+        view = self.valueView
+        if view:
+            view.color = self.normal_color
+        
     def refresh_value(self, value):
         view = self.valueView
         if view:
@@ -274,7 +289,8 @@ class CustomizableGauge(ButtonBehavior, SingleChannelGauge):
         
     def updateColors(self):
         view = self.valueView
-        if view: view.color = self.select_alert_color()
+        if view:
+            view.color = self.select_alert_color()
 
     def showChannelSelectDialog(self):  
         content = ChannelSelectView(settings=self.settings, channel=self.channel)

--- a/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
@@ -1,5 +1,4 @@
 import kivy
-import traceback
 kivy.require('1.9.0')
 from kivy.properties import ListProperty, StringProperty, NumericProperty, ObjectProperty, DictProperty,\
     BooleanProperty
@@ -92,7 +91,6 @@ class Gauge(AnchorLayout):
             self.title = title
         except Exception as e:
             Logger.error('Gauge: Failed to update gauge title & units ' + str(e) + ' ' + str(title))
-            traceback.print_exc()
                  
     def on_channel_meta(self, channel_metas):
         pass

--- a/autosportlabs/racecapture/views/dashboard/widgets/graphicalgauge.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/graphicalgauge.py
@@ -3,9 +3,9 @@ kivy.require('1.9.0')
 from utils import kvFind
 from kivy.core.window import Window
 from kivy.properties import NumericProperty
-from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge
+from autosportlabs.racecapture.views.dashboard.widgets.gauge import CustomizableGauge
 
-class GraphicalGauge(Gauge):
+class GraphicalGauge(CustomizableGauge):
     _gaugeView = None
     gauge_size = NumericProperty(0)
     

--- a/autosportlabs/racecapture/views/dashboard/widgets/laptime.kv
+++ b/autosportlabs/racecapture/views/dashboard/widgets/laptime.kv
@@ -4,8 +4,9 @@
     value_size: self.height
     FieldLabel:
         text: root.NULL_LAP_TIME
-        color: [0.5, 0.5, 0.5, 1.0]
+        #color: [0.5, 0.5, 0.5, 1.0]
         id: value
+        halign: 'center'
     
 <Laptime>:
 	anchor_x: 'center'
@@ -13,5 +14,5 @@
 	value_size: self.height
 	FieldLabel:
 		text: root.NULL_LAP_TIME
-		color: [0.5, 0.5, 0.5, 1.0]
+		#color: [0.5, 0.5, 0.5, 1.0]
 		id: value

--- a/autosportlabs/racecapture/views/dashboard/widgets/laptime.kv
+++ b/autosportlabs/racecapture/views/dashboard/widgets/laptime.kv
@@ -1,3 +1,12 @@
+<CurrentLaptime>:
+    anchor_x: 'center'
+    anchor_y: 'center'
+    value_size: self.height
+    FieldLabel:
+        text: root.NULL_LAP_TIME
+        color: [0.5, 0.5, 0.5, 1.0]
+        id: value
+    
 <Laptime>:
 	anchor_x: 'center'
 	anchor_y: 'center'

--- a/autosportlabs/racecapture/views/dashboard/widgets/laptime.kv
+++ b/autosportlabs/racecapture/views/dashboard/widgets/laptime.kv
@@ -4,7 +4,6 @@
     value_size: self.height
     FieldLabel:
         text: root.NULL_LAP_TIME
-        #color: [0.5, 0.5, 0.5, 1.0]
         id: value
         halign: 'center'
     
@@ -14,5 +13,4 @@
 	value_size: self.height
 	FieldLabel:
 		text: root.NULL_LAP_TIME
-		#color: [0.5, 0.5, 0.5, 1.0]
 		id: value

--- a/autosportlabs/racecapture/views/dashboard/widgets/laptime.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/laptime.py
@@ -6,15 +6,15 @@ from kivy.metrics import dp
 from kivy.graphics import Color
 from utils import kvFind
 from fieldlabel import FieldLabel
-from kivy.properties import BoundedNumericProperty, StringProperty
-from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge
+from kivy.properties import BoundedNumericProperty, StringProperty, NumericProperty
+from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge, SingleChannelGauge
 
 Builder.load_file('autosportlabs/racecapture/views/dashboard/widgets/laptime.kv')
 
 MIN_LAP_TIME=0
 MAX_LAP_TIME=99.999
-
-class Laptime(Gauge):
+    
+class Laptime(SingleChannelGauge):
     NULL_LAP_TIME='--:--.---'
     value = BoundedNumericProperty(0, min=MIN_LAP_TIME, max=MAX_LAP_TIME, errorhandler=lambda x: MAX_LAP_TIME if x > MAX_LAP_TIME else MIN_LAP_TIME)
     halign = StringProperty(None)
@@ -48,4 +48,38 @@ class Laptime(Gauge):
     def on_touch_up(self, touch, *args):
         pass
         
+
+class CurrentLaptime(Laptime):
+    NULL_LAP_TIME='--:--.---'
+    last_laptime = NumericProperty(None)
+    elapsed_time = NumericProperty(None)
+    predicted_time = NumericProperty(None)
+    current_lap = NumericProperty(None)
+    
+    def on_data_bus(self, instance, value):
+        print("currentLaptime onDAtabus")
+        dataBus = self.data_bus
+        channel = self.channel
+        if dataBus and channel:
+            dataBus.addMetaListener(self.on_channel_meta)
+            dataBus.addChannelListener("LapTime", self.set_lap_time)
+            dataBus.addChannelListener("ElapsedTime" , self.set_elapsed_time)
+            dataBus.addChannelListener("PredTime", self.set_predicted_time)
+            dataBus.addChannelListener("LapCount", self.set_lap_count)
+            dataBus.addChannelListener("CurrentLap", self.set_current_lap)
+
+    def set_lap_time(self, value):
+        pass
+    
+    def set_elapsed_time(self, value):
+        pass
+    
+    def set_predicted_time(self, value):
+        pass
+    
+    def set_lap_count(self, value):
+        pass
+    
+    def set_current_lap(self, value):
+        pass
         

--- a/autosportlabs/racecapture/views/dashboard/widgets/laptime.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/laptime.py
@@ -2,11 +2,12 @@ import kivy
 kivy.require('1.9.0')
 from kivy.uix.boxlayout import BoxLayout
 from kivy.app import Builder
+from kivy.clock import Clock
 from kivy.metrics import dp
 from kivy.graphics import Color
 from utils import kvFind
 from fieldlabel import FieldLabel
-from kivy.properties import BoundedNumericProperty, StringProperty, NumericProperty
+from kivy.properties import BoundedNumericProperty, StringProperty, NumericProperty, ObjectProperty
 from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge, SingleChannelGauge
 
 Builder.load_file('autosportlabs/racecapture/views/dashboard/widgets/laptime.kv')
@@ -17,7 +18,6 @@ MAX_LAP_TIME=99.999
 class Laptime(SingleChannelGauge):
     NULL_LAP_TIME='--:--.---'
     value = BoundedNumericProperty(0, min=MIN_LAP_TIME, max=MAX_LAP_TIME, errorhandler=lambda x: MAX_LAP_TIME if x > MAX_LAP_TIME else MIN_LAP_TIME)
-    halign = StringProperty(None)
         
     def __init__(self, **kwargs):
         super(Laptime, self).__init__(**kwargs)
@@ -34,52 +34,125 @@ class Laptime(SingleChannelGauge):
                     view.text = self.NULL_LAP_TIME
                 else:
                     view.text = '{}:{}'.format(intMinuteValue,'{0:06.3f}'.format(fractionMinuteValue))
-        self.updateColors()
-
-    def on_halign(self, instance, value):
-        self.valueView.halign = value 
         
-    def on_touch_down(self, touch, *args):
-        pass
-
-    def on_touch_move(self, touch, *args):
-        pass
-
-    def on_touch_up(self, touch, *args):
-        pass
+    def on_normal_color(self, instance, value):
+        self.valueView.color = value
         
-
-class CurrentLaptime(Laptime):
+class CurrentLaptime(Gauge):
+    _FLASH_INTERVAL = 0.25
+    _FLASH_COUNT = 10
     NULL_LAP_TIME='--:--.---'
+    _elapsed_time = 0
+    _lap_time = 0
+    _predicted_time = 0
+    _current_lap = 0
+    _lap_count = None
+    _new_lap = False
+    _flash_count = 0
+
+    halign = StringProperty(None)
+    valign = StringProperty(None)
+    
+    value = ObjectProperty(None)    
+        
+    _value_view = None
     last_laptime = NumericProperty(None)
     elapsed_time = NumericProperty(None)
     predicted_time = NumericProperty(None)
     current_lap = NumericProperty(None)
     
+    def on_halign(self, instance, value):
+        self.valueView.halign = value 
+    
+    def on_valign(self, instance, value):
+        self.valueView.valign = value 
+
+    def on_normal_color(self, instance, value):
+        self.valueView.color = value
+
+    def on_value_size(self, instance, value):
+        view = self.valueView
+        if view:
+            view.font_size = value
+    
     def on_data_bus(self, instance, value):
-        print("currentLaptime onDAtabus")
-        dataBus = self.data_bus
-        channel = self.channel
-        if dataBus and channel:
-            dataBus.addMetaListener(self.on_channel_meta)
-            dataBus.addChannelListener("LapTime", self.set_lap_time)
-            dataBus.addChannelListener("ElapsedTime" , self.set_elapsed_time)
-            dataBus.addChannelListener("PredTime", self.set_predicted_time)
-            dataBus.addChannelListener("LapCount", self.set_lap_count)
-            dataBus.addChannelListener("CurrentLap", self.set_current_lap)
+        data_bus = self.data_bus
+        if data_bus:
+            data_bus.addMetaListener(self.on_channel_meta)
+            data_bus.addChannelListener("ElapsedTime" , self.set_elapsed_time)
+            data_bus.addChannelListener("LapTime", self.set_lap_time)
+            data_bus.addChannelListener("PredTime", self.set_predicted_time)
+            data_bus.addChannelListener("CurrentLap", self.set_current_lap)
+            data_bus.addChannelListener("LapCount", self.set_lap_count)
 
     def set_lap_time(self, value):
-        pass
+        self._lap_time = value
     
     def set_elapsed_time(self, value):
-        pass
+        self._elapsed_time = value
+        self.update_value()
     
     def set_predicted_time(self, value):
-        pass
+        self._predicted_time = value
+        self.update_value()
     
     def set_lap_count(self, value):
-        pass
+        if value > self._lap_count and self._current_lap > 0:
+            self._new_lap = True
+            self._flash_count = 0
+            self.flash_value()
+        self._lap_count = value
     
     def set_current_lap(self, value):
-        pass
+        self._current_lap = value
+        self.update_value()
+    
+    def flash_value(self):
+        self.value = self._lap_time if self._flash_count % 2 == 0 else ''
+        self._flash_count += 1
+        if self._flash_count < self._FLASH_COUNT * 2:
+            Clock.schedule_once(lambda dt: self.flash_value(), self._FLASH_INTERVAL)
+        else:
+            self._new_lap = False
+        
+    """"
+    Display logic:
+    if we haven't completed a lap yet, only display elapsed time to give a stopwatch effect
+    if we've completed a lap, flash last lap time for 5 seconds,
+    then show predicted time, if present in stream. if not present, show last lap time statically
+    """ 
+    def update_value(self):
+        if not self._new_lap:
+            if self._lap_count == 0:
+                self.value = self._elapsed_time
+            else:
+                if self._predicted_time > 0:
+                    self.value = self._predicted_time
+                else:
+                    self.value = self._lap_time
+        
+    @property
+    def valueView(self):
+        if not self._value_view:
+            self._value_view = self.ids.value
+        return self._value_view
+
+    def on_value(self, instance, value):
+        view = self.valueView
+        if view:
+            if value == '':
+                view.text = ''
+            else:
+                if value == None:
+                    view.text = self.NULL_LAP_TIME
+                else:
+                    intMinuteValue = int(value)
+                    fractionMinuteValue = 60.0 * (value - float(intMinuteValue))
+                    if value == MIN_LAP_TIME:
+                        view.text = self.NULL_LAP_TIME
+                    else:
+                        view.text = '{}:{}'.format(intMinuteValue,'{0:06.3f}'.format(fractionMinuteValue))
+
+    def on_halign(self, instance, value):
+        self.valueView.halign = value 
         

--- a/autosportlabs/racecapture/views/dashboard/widgets/laptime.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/laptime.py
@@ -7,7 +7,7 @@ from kivy.metrics import dp
 from kivy.graphics import Color
 from utils import kvFind
 from fieldlabel import FieldLabel
-from kivy.properties import BoundedNumericProperty, StringProperty, NumericProperty, ObjectProperty
+from kivy.properties import BoundedNumericProperty, StringProperty, ObjectProperty
 from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge, SingleChannelGauge
 
 Builder.load_file('autosportlabs/racecapture/views/dashboard/widgets/laptime.kv')
@@ -46,21 +46,16 @@ class CurrentLaptime(Gauge):
     _lap_time = 0
     _predicted_time = 0
     _current_lap = 0
-    _lap_count = None
+    _lap_count = 0
+    
     _new_lap = False
     _flash_count = 0
+    _value_view = None
 
     halign = StringProperty(None)
     valign = StringProperty(None)
-    
     value = ObjectProperty(None)    
-        
-    _value_view = None
-    last_laptime = NumericProperty(None)
-    elapsed_time = NumericProperty(None)
-    predicted_time = NumericProperty(None)
-    current_lap = NumericProperty(None)
-    
+            
     def on_halign(self, instance, value):
         self.valueView.halign = value 
     
@@ -153,6 +148,4 @@ class CurrentLaptime(Gauge):
                     else:
                         view.text = '{}:{}'.format(intMinuteValue,'{0:06.3f}'.format(fractionMinuteValue))
 
-    def on_halign(self, instance, value):
-        self.valueView.halign = value 
         

--- a/autosportlabs/racecapture/views/dashboard/widgets/timedelta.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/timedelta.py
@@ -7,7 +7,7 @@ from kivy.graphics import Color
 from utils import kvFind
 from fieldlabel import FieldLabel
 from kivy.properties import BoundedNumericProperty, ObjectProperty, BooleanProperty, StringProperty
-from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge
+from autosportlabs.racecapture.views.dashboard.widgets.gauge import SingleChannelGauge
 Builder.load_file('autosportlabs/racecapture/views/dashboard/widgets/timedelta.kv')
 
 MIN_TIME_DELTA  = -99.0
@@ -16,10 +16,9 @@ MAX_TIME_DELTA  = 99.0
 DEFAULT_AHEAD_COLOR  = [0.0, 1.0 , 0.0, 1.0]
 DEFAULT_BEHIND_COLOR = [1.0, 0.65, 0.0 ,1.0]
 
-class TimeDelta(Gauge):
+class TimeDelta(SingleChannelGauge):
     ahead_color = ObjectProperty(DEFAULT_AHEAD_COLOR)
     behind_color = ObjectProperty(DEFAULT_BEHIND_COLOR)
-    halign = StringProperty(None)
     NULL_TIME_DELTA = u'--.-\u2206'    
     
     def __init__(self, **kwargs):
@@ -38,10 +37,7 @@ class TimeDelta(Gauge):
 
     def update_delta_color(self):
         self.valueView.color = self.ahead_color if self.value < 0 else self.behind_color
-        
-    def on_halign(self, instance, value):
-        self.valueView.halign = value 
-        
+                
     def on_touch_down(self, touch, *args):
         pass
 

--- a/resource/channel_meta/system_channels.json
+++ b/resource/channel_meta/system_channels.json
@@ -643,7 +643,7 @@
             "nm": "LapDelta",
             "ut": "Min",
             "sys": 1,
-            "type": 4,
+            "type": 5,
             "prec": 1,
             "min": 0,
             "max": 0


### PR DESCRIPTION
Video: https://www.youtube.com/watch?v=Uj9firfhKuQ

* LapTime gauges have a new behavior with the following display logic:

1) Before completing 1 lap, only display elapsed time since beginning of start/finish to provide a stopwatch effect
2) Upon completing a lap, flash the freshly completed lap time for 5 seconds.
3) Then show predicted time, if present in data stream. if not present, show last lap time statically
4) rinse / repeat on subsequent laps

LapTime widget behavior is consistent anywhere this LapTime widget is added in the dashboard views.

* Refactored gauge class into CustomizableGauge and SingleChannelGauge

* De-cluttered Tachometer view