### PR TITLE
Add Sentry support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ doeet*.sh
 Kivy.App
 RaceCapture.dmg
 RaceCapture.App
+
+#Crash reporting
+.sentry

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Dependencies:
 
     /Applications/Kivy.app/Contents/Resources/script main.py
 
+
+## Building releases (all platforms)
+1. Add a .sentry file with the app's platform-specific DSN for Sentry
+1. Follow the platform-specific build instructions
+
 ## Preparing to build installers (OSX)
 
 1. Make sure all dependencies are installed inside Kivy's venv 

--- a/main.py
+++ b/main.py
@@ -281,7 +281,6 @@ class RaceCaptureApp(App):
         self._telemetry_connection.telemetry_enabled = False
 
     def showMainView(self, view_name):
-        error = 1/0
         try:
             view = self.mainViews.get(view_name)
             if not view:

--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ if __name__ == '__main__':
     import logging
     import argparse
     import kivy
+    import os
+    import traceback
     from kivy.properties import AliasProperty
     from functools import partial
     from kivy.clock import Clock
@@ -45,6 +47,13 @@ if __name__ == '__main__':
     if not is_mobile_platform():
         kivy.config.Config.set ( 'input', 'mouse', 'mouse,disable_multitouch' )
 
+    # If we have a Sentry config file, create a client to send crash reports to
+    if os.path.isfile('.sentry'):
+        import raven
+        # .sentry file contains our Sentry DSN
+        sentry_file = open('.sentry', 'r')
+        dsn = sentry_file.read().rstrip()
+        sentry_client = raven.Client(dsn=dsn, release=__version__)
 
 from kivy.app import App, Builder
 from autosportlabs.racecapture.config.rcpconfig import RcpConfig, VersionConfig
@@ -272,6 +281,7 @@ class RaceCaptureApp(App):
         self._telemetry_connection.telemetry_enabled = False
 
     def showMainView(self, view_name):
+        error = 1/0
         try:
             view = self.mainViews.get(view_name)
             if not view:
@@ -308,7 +318,7 @@ class RaceCaptureApp(App):
         status_view = StatusView(self.trackManager, self._status_pump, name='status')
         self.tracks_listeners.append(status_view)
         return status_view
-    
+
     def build_tracks_view(self):
         tracks_view = TracksView(name='tracks', track_manager=self.trackManager)
         self.tracks_listeners.append(tracks_view)
@@ -486,4 +496,12 @@ class RaceCaptureApp(App):
                 self._telemetry_connection.telemetry_enabled = False
 
 if __name__ == '__main__':
-    RaceCaptureApp().run()
+    try:
+        RaceCaptureApp().run()
+    except:
+        if 'sentry_client' in globals():
+            ident = sentry_client.captureException()
+            Logger.error("Exception caught; reference is %s" % ident)
+            traceback.print_exc()
+        else:
+            raise


### PR DESCRIPTION
Adds basic support for sending crash logs to Sentry.

If a .sentry config file exists locally, it will create a client and send all uncaught exceptions to it. 