### PR TITLE
Deviceid cleanup

### DIFF
--- a/autosportlabs/racecapture/views/configuration/rcp/telemetryconfigview.kv
+++ b/autosportlabs/racecapture/views/configuration/rcp/telemetryconfigview.kv
@@ -9,8 +9,9 @@
 		text: 'Telemetry Configuration'
 		halign: 'left'
 	SettingsView:
-		size_hint_y: 0.3
 		rcid: 'deviceId'
+		id: device_id
+		size_hint_y: 0.10
 		label_text: 'Telemetry Device Id'
 		help_text: 'Enter the telemetry Device Id provided by race-capture.com'
 		

--- a/autosportlabs/racecapture/views/configuration/rcp/telemetryconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/telemetryconfigview.py
@@ -29,6 +29,7 @@ class TelemetryConfigView(BaseConfigView):
         bgStream = kvFind(self, 'rcid', 'bgStream')
         bgStream.bind(on_setting=self.on_bg_stream)
         bgStream.setControl(SettingsSwitch())
+        self.ids.device_id.ids.error.markup = True
         
     def on_device_id(self, instance, value):
         if self.connectivityConfig:
@@ -41,7 +42,7 @@ class TelemetryConfigView(BaseConfigView):
                     self.connectivityConfig.stale = True
                     self.dispatch('on_modified')
                 else:
-                    self.ids.device_id.ids.error.text = 'Invalid device id. Id must only be numbers and letters.'
+                    self.ids.device_id.ids.error.text = '[color=#E50000]Id should contain only numbers and letters.[/color]'
 
     def on_bg_stream(self, instance, value):
         if self.connectivityConfig:

--- a/autosportlabs/racecapture/views/configuration/rcp/telemetryconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/telemetryconfigview.py
@@ -31,7 +31,6 @@ class TelemetryConfigView(BaseConfigView):
         bgStream.setControl(SettingsSwitch())
         
     def on_device_id(self, instance, value):
-        Logger.info("TelemetryConfig: got id:  " + value )
         if self.connectivityConfig:
             value = strip_whitespace(value)
             self.ids.device_id.ids.error.text = ''

--- a/autosportlabs/racecapture/views/configuration/rcp/telemetryconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/telemetryconfigview.py
@@ -1,8 +1,10 @@
 import kivy
 kivy.require('1.9.0')
 from kivy.app import Builder
+from kivy.logger import Logger
 from kivy.uix.boxlayout import BoxLayout
-import json
+import re
+
 
 from settingsview import SettingsView, SettingsTextField, SettingsSwitch
 from autosportlabs.widgets.separator import HLineSeparator
@@ -14,6 +16,7 @@ TELEMETRY_CONFIG_VIEW_KV = 'autosportlabs/racecapture/views/configuration/rcp/te
 
 class TelemetryConfigView(BaseConfigView):
     connectivityConfig = None
+
     def __init__(self, **kwargs):    
         Builder.load_file(TELEMETRY_CONFIG_VIEW_KV)
         super(TelemetryConfigView, self).__init__(**kwargs)
@@ -28,11 +31,19 @@ class TelemetryConfigView(BaseConfigView):
         bgStream.setControl(SettingsSwitch())
         
     def on_device_id(self, instance, value):
+        Logger.info("TelemetryConfig: got id:  " + value )
         if self.connectivityConfig:
-            self.connectivityConfig.telemetryConfig.deviceId = value
-            self.connectivityConfig.stale = True
-            self.dispatch('on_modified')
-                
+            value = value.strip()
+            self.ids.device_id.ids.error.text = ''
+            if len(value) > 0:
+                if self.validate_device_id(value):
+                    kvFind(self, 'rcid', 'deviceId').setValue(value)
+                    self.connectivityConfig.telemetryConfig.deviceId = value
+                    self.connectivityConfig.stale = True
+                    self.dispatch('on_modified')
+                else:
+                    self.ids.device_id.ids.error.text = 'Invalid device id. Id must only be numbers and letters.'
+
     def on_bg_stream(self, instance, value):
         if self.connectivityConfig:
             self.connectivityConfig.telemetryConfig.backgroundStreaming = value
@@ -44,8 +55,6 @@ class TelemetryConfigView(BaseConfigView):
         kvFind(self, 'rcid', 'bgStream').setValue(connectivityConfig.telemetryConfig.backgroundStreaming)
         kvFind(self, 'rcid', 'deviceId').setValue(connectivityConfig.telemetryConfig.deviceId)
         self.connectivityConfig = connectivityConfig
-        
-        
-        
-        
-    
+
+    def validate_device_id(self, device_id):
+        return device_id.isalnum()

--- a/autosportlabs/racecapture/views/configuration/rcp/wirelessconfigview.kv
+++ b/autosportlabs/racecapture/views/configuration/rcp/wirelessconfigview.kv
@@ -39,7 +39,7 @@
         		help_text: 'Enable if the Real-time telemetry module is installed'
         
         	SettingsView:
-        		size_hint_y: 0.25
+        		size_hint_y: 0.5
         		rcid: 'cellprovider'
         		label_text: 'Cellular Provider'
         		help_text: 'Select the cellular provider, or specify custom APN settings'

--- a/settingsview.kv
+++ b/settingsview.kv
@@ -7,7 +7,7 @@
         BoxLayout:
             orientation: 'vertical'
             spacing: 5
-            size_hint: (0.6, 1.0)
+            size_hint: (0.65, 1.0)
             FieldLabel:
                 size_hint: (1, 1.0)
                 rcid: 'fieldLabel'
@@ -21,7 +21,7 @@
                 text: ''
         BoxLayout:
             padding: [0, 10, 0, 10]
-            size_hint: (0.4, 1.0)
+            size_hint: (0.35, 1.0)
             orientation: 'vertical'
             halign: 'left'
             spacing: 5

--- a/settingsview.kv
+++ b/settingsview.kv
@@ -1,31 +1,43 @@
 #:kivy 1.9.0
 
 <SettingsView>:
-	orientation: 'vertical'
-	BoxLayout:
-		size_hint_y: 0.25
-		rcid: 'fieldContainer'
-		orientation: 'horizontal'
-		FieldLabel:
-			size_hint: (0.6, 1.0)
-			rcid: 'fieldLabel'
-			halign: 'right'
-			font_size: sp(20)
-			text: ''
-		AnchorLayout:
-			anchor_x: 'center'
-			anchor_y: 'center'
-			size_hint: (0.4, 1.0)
-			rcid: 'control'
-	HelpLabel:
-		size_hint_y: 0.75
-		rcid: 'helpLabel'
-		halign: 'left'
-		text: ''
+    BoxLayout:
+        rcid: 'fieldContainer'
+        orientation: 'horizontal'
+        BoxLayout:
+            orientation: 'vertical'
+            spacing: 5
+            size_hint: (0.6, 1.0)
+            FieldLabel:
+                size_hint: (1, 1.0)
+                rcid: 'fieldLabel'
+                halign: 'right'
+                font_size: sp(20)
+                text: ''
+            HelpLabel:
+                size_hint: (1, 1.0)
+                rcid: 'helpLabel'
+                halign: 'right'
+                text: ''
+        BoxLayout:
+            padding: [0, 10, 0, 10]
+            size_hint: (0.4, 1.0)
+            orientation: 'vertical'
+            halign: 'left'
+            spacing: 5
+            BoxLayout:
+                padding: [10,0]
+                rcid: 'control'
+                halign: 'left'
+            HelpLabel:
+                padding: [10,2]
+                size_hint_x: 1
+                id: error
+                halign: 'left'
+                text: ''
 
 <SettingsMappedSpinner>:
 	rcid: 'settingsCtrl'
-	size_hint: (0.6, 0.3)
 	on_text: root.on_text(*args)
 	
 <SettingsSwitch>:	
@@ -40,5 +52,5 @@
 	
 <SettingsTextField>:
 	rcid: 'settingsCtrl'
-	size_hint: (0.6, 0.3)
+	size_hint: (0.5, 0.3)
 	on_text: root.on_text(*args)

--- a/settingsview.kv
+++ b/settingsview.kv
@@ -29,10 +29,11 @@
                 padding: [10,0]
                 rcid: 'control'
                 halign: 'left'
-            HelpLabel:
+            TextWidget:
                 padding: [10,2]
                 size_hint_x: 1
                 id: error
+                rcid: 'error'
                 halign: 'left'
                 text: ''
 


### PR DESCRIPTION
I started with stripping whitespace, but it snowballed into adding an error field to the settings view. Now (most) settings have a space to show error messages when the user changes settings.

Added better device id validation. Checks to see if the value entered is alphanumeric.