### PR TITLE
Support any RaceCapture bluetooth device name

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+==1.4.2==
+* Connect to the first RaceCapture device it can detect, regardless of the name provided
+
 ==1.4.1==
 * Fixed firmware update issue for Windows 10
 * Various fixes and improvements on Analysis Beta

--- a/autosportlabs/comms/androidcomms.py
+++ b/autosportlabs/comms/androidcomms.py
@@ -32,24 +32,26 @@ class AndroidComms(object):
         self._bt_conn = BTConn.createInstance();
                                                                 
     def get_available_ports(self):
-        return ['RaceCapturePro'] #TODO get this from the service directly
+        bt_ports = self._bt_conn.getAvailableDevices()
+        Logger.info('AndroidComms: detected ports: {}'.format(bt_ports.join(',')))
+        return bt_ports
     
     def isOpen(self):
         return self._bt_conn.isOpen()
     
     def open(self):
-        Logger.info('androidcomms: Opening connection ' + str(self.port))
+        Logger.info('AndroidComms: Opening connection ' + str(self.port))
         self._bt_conn.open(self.port)
-        Logger.info('androidcomms: after open!!!!!!!!!!!!!!!!')
+        Logger.info('AndroidComms: after open!!!!!!!!!!!!!!!!')
     
     def keep_alive(self):
         pass
     
     def cleanup(self):
-        Logger.info('androidcomms: cleanup')
+        Logger.info('AndroidComms: cleanup')
         
     def close(self):
-        Logger.info('androidcomms: close')
+        Logger.info('AndroidComms: close')
         self._bt_conn.close()
 
     def read_message(self):

--- a/autosportlabs/comms/androidcomms.py
+++ b/autosportlabs/comms/androidcomms.py
@@ -42,7 +42,7 @@ class AndroidComms(object):
     def open(self):
         Logger.info('AndroidComms: Opening connection ' + str(self.port))
         self._bt_conn.open(self.port)
-        Logger.info('AndroidComms: after open!!!!!!!!!!!!!!!!')
+        Logger.info('AndroidComms: after open')
     
     def keep_alive(self):
         pass

--- a/autosportlabs/comms/androidcomms.py
+++ b/autosportlabs/comms/androidcomms.py
@@ -33,7 +33,7 @@ class AndroidComms(object):
                                                                 
     def get_available_ports(self):
         bt_ports = self._bt_conn.getAvailableDevices()
-        Logger.info('AndroidComms: detected ports: {}'.format(bt_ports.join(',')))
+        Logger.info('AndroidComms: detected ports: {}'.format(','.join(bt_ports)))
         return bt_ports
     
     def isOpen(self):

--- a/java/src/com/autosportlabs/racecapture/BluetoothConnection.java
+++ b/java/src/com/autosportlabs/racecapture/BluetoothConnection.java
@@ -181,4 +181,14 @@ public class BluetoothConnection {
 			}
 		}
 	}
+
+	public List<String> getAvailableDevices(){
+        BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        Set<BluetoothDevice> pairedDevices = bluetoothAdapter.getBondedDevices();
+
+        List<String> devices = new ArrayList<String>();
+        for(BluetoothDevice bt : pairedDevices)
+            devices.add(bt.getName());
+        return devices;
+	}
 }

--- a/java/src/com/autosportlabs/racecapture/BluetoothConnection.java
+++ b/java/src/com/autosportlabs/racecapture/BluetoothConnection.java
@@ -6,6 +6,8 @@ import android.util.Log;
 
 import java.util.UUID;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -182,13 +184,14 @@ public class BluetoothConnection {
 		}
 	}
 
-	public List<String> getAvailableDevices(){
+	public String[] getAvailableDevices(){
         BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         Set<BluetoothDevice> pairedDevices = bluetoothAdapter.getBondedDevices();
 
         List<String> devices = new ArrayList<String>();
         for(BluetoothDevice bt : pairedDevices)
             devices.add(bt.getName());
-        return devices;
+
+        return devices.toArray(new String[devices.size()]);
 	}
 }

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 import sys
 import os
 


### PR DESCRIPTION
Allow the android device to pair with multiple RaceCapture bluetooth devices, each with a unique name. The app will connect with the first device it can, regardless of the name. 

Currently the app looks for a fixed RaceCapturePro name. this change will make it compatible with 2.9.0 firmware changes.