### PR TITLE
Add logic that prevents StatusPump from having more than one instance

### DIFF
--- a/autosportlabs/racecapture/status/statuspump.py
+++ b/autosportlabs/racecapture/status/statuspump.py
@@ -27,7 +27,8 @@ class StatusPump(object):
         self._listeners.append(listener)
 
     def start(self, rc_api):
-        if self._status_thread != None and self._status_thread.is_alive():
+        if self._status_thread is not None and \
+           self._status_thread.is_alive():
             Logger.info('StatusPump: Already running')
             return
 

--- a/autosportlabs/racecapture/status/statuspump.py
+++ b/autosportlabs/racecapture/status/statuspump.py
@@ -10,31 +10,35 @@ from threading import Thread
 """Responsible for querying status from the RaceCapture API
 """
 class StatusPump(object):
-    
+
     #how often we query for status
     STATUS_QUERY_INTERVAL = 2.0
-    
+
     #Connection to the RC API
     _rc_api = None
-    
+
     #Things that care about status updates
     _listeners = []
-    
+
     #Worker Thread
     _status_thread = None
-    
+
     def add_listener(self, listener):
         self._listeners.append(listener)
-                    
+
     def start(self, rc_api):
-        Logger.info('StatusPump: starting')
+        if self._status_thread != None and self._status_thread.is_alive():
+            Logger.info('StatusPump: Already running')
+            return
+
+        Logger.info('StatusPump: Starting...')
         self._rc_api = rc_api
         self._status_thread = Thread(target=self.status_worker)
         self._status_thread.daemon = True
         self._status_thread.start()
-        
+
     def status_worker(self):
-        self._rc_api.addListener('status', self._on_status_updated)        
+        self._rc_api.addListener('status', self._on_status_updated)
         while True:
             self._rc_api.get_status()
             sleep(self.STATUS_QUERY_INTERVAL)
@@ -42,6 +46,6 @@ class StatusPump(object):
     def _update_all_listeners(self, status):
         for listener in self._listeners:
             listener(status)
-        
+
     def _on_status_updated(self, status):
         Clock.schedule_once(lambda dt: self._update_all_listeners(status))


### PR DESCRIPTION
Because more than once instance creates unnecessary traffic and threads.  And that makes MK1 a sad panda.