### PR TITLE
Only show active channels in the selection list when RCP is connected

### DIFF
--- a/autosportlabs/racecapture/data/channels.py
+++ b/autosportlabs/racecapture/data/channels.py
@@ -101,6 +101,16 @@ class RuntimeChannels(EventDispatcher):
                 self.channel_names.insert(0,channel_name)
                 channels[channel_name] = copy.copy(runtime_meta)
 
+    def get_active_channels(self):
+        '''
+        Return a dict of active ChannelMeta objects. If we have a data connection, filter for only the currently active channels.
+        If no data connection, send back all System channels
+        :returns dict of ChannelMeta objects, keyed by channel name
+        '''
+        if self.data_bus.rcp_meta_read == True:
+            return self.data_bus.channel_metas.copy()
+        else:
+            return self.channels.copy()
 
 class SystemChannels(EventDispatcher):
     channels = ObjectProperty(None)

--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -65,8 +65,11 @@ class DataBus(object):
         This should be called when the channel information has changed
         """
         self.channel_metas.clear()
+        self.active_channel_names = []
         for meta in metas.channel_metas:
-            self.channel_metas[meta.name] = meta
+            channel_name = meta.name
+            self.channel_metas[channel_name] = meta
+            self.active_channel_names.append(channel_name)
             
         #add channel meta for existing filters
         for f in self.data_filters:

--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -65,11 +65,8 @@ class DataBus(object):
         This should be called when the channel information has changed
         """
         self.channel_metas.clear()
-        self.active_channel_names = []
         for meta in metas.channel_metas:
-            channel_name = meta.name
-            self.channel_metas[channel_name] = meta
-            self.active_channel_names.append(channel_name)
+            self.channel_metas[meta.name] = meta
             
         #add channel meta for existing filters
         for f in self.data_filters:

--- a/autosportlabs/racecapture/views/channels/channelselectview.py
+++ b/autosportlabs/racecapture/views/channels/channelselectview.py
@@ -33,12 +33,12 @@ class ChannelSelectorView(BoxLayout):
         if channels:
             index = 0
             list_adapter = self.ids.channelList.adapter
-            for item in self.ids.channelList.adapter.data:
+            for item in list_adapter.data:
                 if item['text'] in channels:
                     view = list_adapter.get_view(index)
                     view.trigger_action(duration=0) #duration=0 means make it an instant selection
                 index += 1
-        
+
     def on_channels(self, instance, value):    
         '''
         Set the list of available channels for this view.
@@ -50,7 +50,7 @@ class ChannelSelectorView(BoxLayout):
             data.append({'text': str(channel), 'is_selected': False})
         
         args_converter = lambda row_index, rec: {'text': rec['text'], 'size_hint_y': None, 'height': dp(50)}
-        
+
         list_adapter = ListAdapter(data=data,
                            args_converter=args_converter,
                            cls=ChannelItemButton,
@@ -71,20 +71,17 @@ class ChannelSelectorView(BoxLayout):
     
 class ChannelSelectView(FloatLayout):
     channel = None
-    def __init__(self, **kwargs):
+    def __init__(self, settings, channel, **kwargs):
         super(ChannelSelectView, self).__init__(**kwargs)
         self.register_event_type('on_channel_selected')
         self.register_event_type('on_channel_cancel')
-        
-        settings = kwargs.get('settings')
-        type = kwargs.get('type')
-        channel = kwargs.get('channel')
-        
         data = []
         channel_list = self.ids.channelList
+
+        available_channels = list(settings.runtimeChannels.get_active_channels().iterkeys())
+        available_channels.sort()
         try:
-            for available_channel,channelMeta in settings.runtimeChannels.channels.iteritems():
-                channel_type = channelMeta.type
+            for available_channel in available_channels:
                 data.append({'text': available_channel, 'is_selected': False})
                 
             args_converter = lambda row_index, rec: {'text': rec['text'], 'size_hint_y': None, 'height': dp(50)}
@@ -95,7 +92,16 @@ class ChannelSelectView(FloatLayout):
                                selection_mode='single',
                                allow_empty_selection=True)
     
-            channel_list.adapter=list_adapter
+            channel_list.adapter = list_adapter
+
+            #select the current channel
+            index = 0
+            for item in list_adapter.data:
+                if item['text'] == channel:
+                    view = list_adapter.get_view(index)
+                    view.trigger_action(duration=0) #duration=0 means make it an instant selection
+                index += 1
+
             list_adapter.bind(on_selection_change=self.on_select)
             self.channel = channel
         except Exception as e:

--- a/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/gauge.py
@@ -278,7 +278,7 @@ class CustomizableGauge(ButtonBehavior, SingleChannelGauge):
         if view:
             view.color = self.select_alert_color()
 
-    def showChannelSelectDialog(self):  
+    def showChannelSelectDialog(self):
         content = ChannelSelectView(settings=self.settings, channel=self.channel)
         content.bind(on_channel_selected=self.channel_selected)
         content.bind(on_channel_cancel=self._dismiss_popup)


### PR DESCRIPTION
Only show active channels in the selection list when RCP is connected - otherwise show the full list of system channels. resolves #829