### PR TITLE
P/stieg/tx timeout ++

### DIFF
--- a/autosportlabs/comms/commscommon.py
+++ b/autosportlabs/comms/commscommon.py
@@ -3,7 +3,7 @@ class ChainableException(Exception):
         m = ''
 
         if cause is not None:
-            m += 'caused by %s' % repr(cause)
+            m += 'caused by {}'.format(repr(cause))
             m.strip()
 
         super(Exception, self).__init__(m)

--- a/autosportlabs/comms/commscommon.py
+++ b/autosportlabs/comms/commscommon.py
@@ -1,5 +1,20 @@
-class PortNotOpenException(Exception):
+class ChainableException(Exception):
+    def __init__(self, cause=None):
+        m = ''
+
+        if cause is not None:
+            m += 'caused by %s' % repr(cause)
+            m.strip()
+
+        super(Exception, self).__init__(m)
+        self.cause = cause
+
+    def get_cause(self):
+        return self.cause
+
+
+class PortNotOpenException(ChainableException):
     pass
 
-class CommsErrorException(Exception):
+class CommsErrorException(ChainableException):
     pass

--- a/autosportlabs/comms/serial/serialconnection.py
+++ b/autosportlabs/comms/serial/serialconnection.py
@@ -26,7 +26,7 @@ class SerialConnection():
         return self.ser != None
 
     def open(self, port):
-        self.ser = serial.Serial(port, timeout=self.timeout, \
+        self.ser = serial.Serial(port, timeout=self.timeout,
                             write_timeout = self.writeTimeout)
 
     def close(self):

--- a/autosportlabs/comms/serial/serialconnection.py
+++ b/autosportlabs/comms/serial/serialconnection.py
@@ -26,9 +26,8 @@ class SerialConnection():
         return self.ser != None
 
     def open(self, port):
-        ser = serial.Serial(port, baudrate=115200, timeout=self.timeout, \
+        self.ser = serial.Serial(port, timeout=self.timeout, \
                             write_timeout = self.writeTimeout)
-        self.ser = ser
 
     def close(self):
         if self.ser != None:

--- a/autosportlabs/comms/serial/serialconnection.py
+++ b/autosportlabs/comms/serial/serialconnection.py
@@ -5,30 +5,31 @@ from autosportlabs.comms.commscommon import PortNotOpenException, CommsErrorExce
 from kivy.logger import Logger
 
 class SerialConnection():
-    DEFAULT_WRITE_TIMEOUT = 1
+    DEFAULT_WRITE_TIMEOUT = 3
     DEFAULT_READ_TIMEOUT = 1
     timeout = DEFAULT_READ_TIMEOUT
-    writeTimeout = DEFAULT_WRITE_TIMEOUT 
-    
+    writeTimeout = DEFAULT_WRITE_TIMEOUT
+
     ser = None
-    
+
     def __init__(self, **kwargs):
         pass
-    
+
     def get_available_ports(self):
         Logger.debug("SerialConnection: getting available ports")
         ports = [x[0] for x in list_ports.comports()]
         ports.sort()
         filtered_ports = filter(lambda port: not port.startswith('/dev/ttyUSB') and not port.startswith('/dev/ttyS') and not port.startswith('/dev/cu.Bluetooth-Incoming-Port'), ports)
         return filtered_ports
-            
+
     def isOpen(self):
         return self.ser != None
-    
+
     def open(self, port):
-        ser = serial.Serial(port, timeout=self.timeout, write_timeout = self.writeTimeout)
+        ser = serial.Serial(port, baudrate=115200, timeout=self.timeout, \
+                            write_timeout = self.writeTimeout)
         self.ser = ser
-            
+
     def close(self):
         if self.ser != None:
             self.ser.close()
@@ -42,9 +43,9 @@ class SerialConnection():
         except SerialException as e:
             if str(e).startswith('device reports readiness'):
                 return ''
-            else: 
+            else:
                 raise
-    
+
     def read_line(self):
         msg = ''
         while True:
@@ -55,22 +56,22 @@ class SerialConnection():
             if msg[-2:] == '\r\n':
                 msg = msg[:-2]
                 return msg
-    
+
     def write(self, data):
         try:
             return self.ser.write(data)
         except SerialException as e:
-            raise CommsErrorException()
-            
-    
+            raise CommsErrorException(cause=e)
+
+
     def flushInput(self):
         try:
             self.ser.flushInput()
         except SerialException as e:
-            raise CommsErrorException()
-    
+            raise CommsErrorException(cause=e)
+
     def flushOutput(self):
         try:
             self.ser.flushOutput()
         except SerialException as e:
-            raise CommsErrorException()
+            raise CommsErrorException(cause=e)


### PR DESCRIPTION
Increases the Tx timeout so that MK1 can have the time it needs to ingest all the data.  Also adds exception chaining support to some of our exceptions so we can see what caused an underlying exception (as we wrap some exceptions for odd reasons).

When this app gets moved to python3 we can use the `from e` method on a `raise` invocation and remove the chaining code I hacked in.