### PR TITLE
Add print Tx/Rx serial stream arg to app without setting Trace

### DIFF
--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -39,18 +39,18 @@ class RcpCmd:
         self.payload = payload
         self.index = index
         self.option = option
-            
+
 class CommandSequence():
     command_list = None
     rootName = None
     winCallback = None
     failCallback = None
-            
+
 class RcpApi:
     detect_win_callback = None
     detect_fail_callback = None
     detect_activity_callback = None
-    comms = None   
+    comms = None
     msgListeners = {}
     cmdSequenceQueue = Queue.Queue()
     _command_queue = Queue.Queue()
@@ -64,14 +64,14 @@ class RcpApi:
     _msg_rx_thread = None
     _auto_detect_event = Event()
     _auto_detect_busy = Event()
-    
+
     def __init__(self, **kwargs):
         self.comms = kwargs.get('comms', self.comms)
         self._running = Event()
         self._running.clear()
         self._enable_autodetect = Event()
         self._enable_autodetect.set()
-
+        self._print_tx_rx = kwargs.get('print_tx_rx')
         self._disconnect_callback = kwargs.get('on_disconnect')
 
     def enable_autorecover(self):
@@ -81,7 +81,7 @@ class RcpApi:
     def disable_autorecover(self):
         Logger.info("RCPAPI: Disabling auto recover")
         self._enable_autodetect.clear()
-        
+
     def recover_connection(self):
         if self._disconnect_callback:
             self._disconnect_callback()
@@ -100,7 +100,7 @@ class RcpApi:
         Logger.info('RCPAPI: Stopping msg rx worker')
         self._running.clear()
         self._msg_rx_thread.join()
-    
+
     def _start_cmd_sequence_worker(self):
         self._cmd_sequence_thread = Thread(target=self.cmd_sequence_worker)
         self._cmd_sequence_thread.daemon = True
@@ -112,10 +112,10 @@ class RcpApi:
         self._start_cmd_sequence_worker()
         self.start_auto_detect_worker()
         Clock.schedule_interval(lambda dt: comms.keep_alive(), COMMS_KEEP_ALIVE_TIMEOUT)
-        
+
     def cleanup_comms(self):
         self.comms.cleanup()
-        
+
     def shutdown_comms(self):
         Logger.info('RCPAPI: shutting down comms')
         try:
@@ -123,16 +123,16 @@ class RcpApi:
             self.comms.port = None
         except:
             pass
-        
+
     def detect_win(self, version_info):
         self.level_2_retries = DEFAULT_LEVEL2_RETRIES
         self.msg_rx_timeout = DEFAULT_MSG_RX_TIMEOUT
         if self.detect_win_callback: self.detect_win_callback(version_info)
-        
+
     def run_auto_detect(self):
         self.level_2_retries = AUTODETECT_LEVEL2_RETRIES
         self.msg_rx_timeout = self.comms.CONNECT_TIMEOUT
-        self._auto_detect_event.set()                
+        self._auto_detect_event.set()
 
     def addListener(self, messageName, callback):
         listeners = self.msgListeners.get(messageName, None)
@@ -147,7 +147,7 @@ class RcpApi:
         listeners = self.msgListeners.get(messageName, None)
         if listeners:
             listeners.discard(callback)
-            
+
     def msg_rx_worker(self):
         Logger.info('RCPAPI: msg_rx_worker started')
         comms = self.comms
@@ -159,7 +159,13 @@ class RcpApi:
                 if msg:
                     #clean incoming string, and drop illegal characters
                     msg = unicode(msg, errors='ignore')
-                    Logger.trace('RCPAPI: msg_rx_worker Rx: ' + str(msg))
+
+                    log_msg = 'RCPAPI: Rx: ' + str(msg)
+                    if self._print_tx_rx:
+                        Logger.info(log_msg)
+                    else:
+                        Logger.trace(log_msg)
+
                     msgJson = json.loads(msg, strict = False)
                     self.on_rx(True)
                     error_count = 0
@@ -174,10 +180,10 @@ class RcpApi:
                                     Logger.error('RCPAPI: Message Listener Exception for')
                                     Logger.debug(traceback.format_exc())
                             break
-                    msg = ''                        
+                    msg = ''
                 else:
                     sleep(NO_DATA_AVAILABLE_DELAY)
-                    
+
             except PortNotOpenException:
                 Logger.debug("RCPAPI: Port not open...")
                 msg=''
@@ -193,12 +199,12 @@ class RcpApi:
                     sleep(5)
                 else:
                     sleep(0.25)
-                    
+
         Logger.info("RCPAPI: RxWorker exiting")
-                    
+
     def rcpCmdComplete(self, msgReply):
         self.cmdSequenceQueue.put(msgReply)
-                
+
     def recoverTimeout(self):
         Logger.warn('RCPAPI: POKE')
         self.comms.write_message(' ')
@@ -206,7 +212,7 @@ class RcpApi:
     def notifyProgress(self, count, total):
         if self.on_progress:
             self.on_progress((float(count) / float(total)) * 100)
-        
+
     def executeSingle(self, cmd, win_callback, fail_callback):
         command = CommandSequence()
         command.command_list = [cmd]
@@ -214,7 +220,7 @@ class RcpApi:
         command.winCallback = win_callback
         command.failCallback = fail_callback
         self._command_queue.put(command)
-        
+
     def _queue_multiple(self, command_list, root_name, win_callback, fail_callback):
         command = CommandSequence()
         command.command_list = command_list
@@ -222,24 +228,24 @@ class RcpApi:
         command.winCallback = win_callback
         command.failCallback = fail_callback
         self._command_queue.put(command)
-                
+
     def cmd_sequence_worker(self):
         while True:
             try:
                 command = self._command_queue.get() #this blocks forever
-                
+
                 command_list = command.command_list
                 rootName = command.rootName
                 winCallback = command.winCallback
                 failCallback = command.failCallback
                 comms = self.comms
-                
+
                 Logger.info('RCPAPI: Execute Sequence begin')
-                
+
                 if not comms.isOpen(): self.run_auto_detect()
-                        
+
                 q = self.cmdSequenceQueue
-                
+
                 responseResults = {}
                 cmdCount = 0
                 cmdLength = len(command_list)
@@ -249,11 +255,11 @@ class RcpApi:
                         payload = rcpCmd.payload
                         index = rcpCmd.index
                         option = rcpCmd.option
-        
+
                         level2Retry = 0
                         name = rcpCmd.name
                         result = None
-                        
+
                         self.addListener(name, self.rcpCmdComplete)
                         while not result and level2Retry <= self.level_2_retries:
                             if not payload == None and not index == None and not option == None:
@@ -264,7 +270,7 @@ class RcpApi:
                                 rcpCmd.cmd(payload)
                             else:
                                 rcpCmd.cmd()
-        
+
                             retry = 0
                             while not result and retry < DEFAULT_READ_RETRIES:
                                 try:
@@ -280,22 +286,22 @@ class RcpApi:
                             if not result:
                                 Logger.info('RCPAPI: Level 2 retry for (' + str(level2Retry) + ') ' + name)
                                 level2Retry += 1
-        
-        
+
+
                         if not result:
                             raise Exception('Timeout waiting for ' + name)
-                                    
-                                            
+
+
                         responseResults[name] = result[name]
                         self.removeListener(name, self.rcpCmdComplete)
                         cmdCount += 1
                         self.notifyProgress(cmdCount, cmdLength)
-                        
+
                     if rootName:
                         winCallback({rootName: responseResults})
                     else:
                         winCallback(responseResults)
-                    
+
                 except CommsErrorException:
                     self.recover_connection()
                 except Exception as detail:
@@ -305,7 +311,7 @@ class RcpApi:
                     self.recover_connection()
 
                 Logger.info('RCPAPI: Execute Sequence complete')
-                
+
             except Exception as e:
                 Logger.error('RCPAPI: Execute command exception ' + str(e))
 
@@ -313,19 +319,25 @@ class RcpApi:
         try:
             self.sendCommandLock.acquire()
             rsp = None
-            
+
             comms = self.comms
 
             cmdStr = json.dumps(cmd, separators=(',', ':')) + '\r'
-            Logger.trace('RCPAPI: send cmd: ' + cmdStr)
+
+            log_msg = 'RCPAPI: Tx: ' + cmdStr
+            if self._print_tx_rx:
+                Logger.info(log_msg)
+            else:
+                Logger.trace(log_msg)
+
             comms.write_message(cmdStr)
         except Exception:
             self.recover_connection()
         finally:
             self.sendCommandLock.release()
             self.on_tx(True)
-        
-        
+
+
     def sendGet(self, name, index = None):
         if index == None:
             index = None
@@ -336,14 +348,14 @@ class RcpApi:
 
     def sendSet(self, name, payload, index = None):
         if not index == None:
-            self.sendCommand({name: {str(index): payload}})            
+            self.sendCommand({name: {str(index): payload}})
         else:
             self.sendCommand({name: payload})
-                            
+
     def getRcpCfgCallback(self, cfg, rcpCfgJson, winCallback):
         cfg.fromJson(rcpCfgJson)
         winCallback(cfg)
-        
+
     def getRcpCfg(self, cfg, winCallback, failCallback):
         cmdSequence = [       RcpCmd('ver',         self.sendGetVersion),
                               RcpCmd('capabilities',self.getCapabilities),
@@ -361,12 +373,12 @@ class RcpApi:
                               RcpCmd('connCfg',     self.getConnectivityCfg),
                               RcpCmd('trackDb',     self.getTrackDb)
                            ]
-                
+
         self._queue_multiple(cmdSequence, 'rcpCfg', lambda rcpJson: self.getRcpCfgCallback(cfg, rcpJson, winCallback), failCallback)
 
     def writeRcpCfg(self, cfg, winCallback = None, failCallback = None):
         cmdSequence = []
-        
+
         connCfg = cfg.connectivityConfig
         if connCfg.stale:
             cmdSequence.append(RcpCmd('setConnCfg', self.setConnectivityCfg, connCfg.toJson()))
@@ -374,7 +386,7 @@ class RcpApi:
         gpsCfg = cfg.gpsConfig
         if gpsCfg.stale:
             cmdSequence.append(RcpCmd('setGpsCfg', self.setGpsCfg, gpsCfg.toJson()))
-        
+
         lapCfg = cfg.lapConfig
         if lapCfg.stale:
             cmdSequence.append(RcpCmd('setLapCfg', self.setLapCfg, lapCfg.toJson()))
@@ -384,25 +396,25 @@ class RcpApi:
             imuChannel = imuCfg.channels[i]
             if imuChannel.stale:
                 cmdSequence.append(RcpCmd('setImuCfg', self.setImuCfg, imuChannel.toJson(), i))
-                
+
         analogCfg = cfg.analogConfig
         for i in range(ANALOG_CHANNEL_COUNT):
             analogChannel = analogCfg.channels[i]
             if analogChannel.stale:
                 cmdSequence.append(RcpCmd('setAnalogCfg', self.setAnalogCfg, analogChannel.toJson(), i))
-        
+
         timerCfg = cfg.timerConfig
         for i in range(TIMER_CHANNEL_COUNT):
             timerChannel = timerCfg.channels[i]
             if timerChannel.stale:
                 cmdSequence.append(RcpCmd('setTimerCfg', self.setTimerCfg, timerChannel.toJson(), i))
-        
+
         gpioCfg = cfg.gpioConfig
         for i in range(GPIO_CHANNEL_COUNT):
             gpioChannel = gpioCfg.channels[i]
             if gpioChannel.stale:
                 cmdSequence.append(RcpCmd('setGpioCfg', self.setGpioCfg, gpioChannel.toJson(), i))
-                 
+
         pwmCfg = cfg.pwmConfig
         for i in range(PWM_CHANNEL_COUNT):
             pwmChannel = pwmCfg.channels[i]
@@ -416,31 +428,31 @@ class RcpApi:
         obd2Cfg = cfg.obd2Config
         if obd2Cfg.stale:
             cmdSequence.append(RcpCmd('setObd2Cfg', self.setObd2Cfg, obd2Cfg.toJson()))
-            
+
         trackCfg = cfg.trackConfig
         if trackCfg.stale:
             cmdSequence.append(RcpCmd('setTrackCfg', self.setTrackCfg, trackCfg.toJson()))
-            
+
         scriptCfg = cfg.scriptConfig
         if scriptCfg.stale:
             self.sequenceWriteScript(scriptCfg.toJson(), cmdSequence)
-            
+
         trackDb = cfg.trackDb
         if trackDb.stale:
             self.sequenceWriteTrackDb(trackDb.toJson(), cmdSequence)
-                
+
         cmdSequence.append(RcpCmd('flashCfg', self.sendFlashConfig))
-        
-        self._queue_multiple(cmdSequence, 'setRcpCfg', winCallback, failCallback)        
+
+        self._queue_multiple(cmdSequence, 'setRcpCfg', winCallback, failCallback)
 
     def resetDevice(self, bootloader=False, reset_delay=0):
         if bootloader:
             loaderint = 1
         else:
             loaderint = 0
-            
+
         self.sendCommand({'sysReset': {'loader':loaderint, 'delay':reset_delay}})
-                
+
     def getAnalogCfg(self, channelId = None):
         self.sendGet('getAnalogCfg', channelId)
 
@@ -449,64 +461,64 @@ class RcpApi:
 
     def getImuCfg(self, channelId = None):
         self.sendGet('getImuCfg', channelId)
-    
+
     def setImuCfg(self, imuCfg, channelId):
         self.sendSet('setImuCfg', imuCfg, channelId)
-    
+
     def getLapCfg(self):
         self.sendGet('getLapCfg', None)
-    
+
     def setLapCfg(self, lapCfg):
         self.sendSet('setLapCfg', lapCfg)
 
     def getGpsCfg(self):
         self.sendGet('getGpsCfg', None)
-    
+
     def setGpsCfg(self, gpsCfg):
         self.sendSet('setGpsCfg', gpsCfg)
-        
+
     def getTimerCfg(self, channelId = None):
         self.sendGet('getTimerCfg', channelId)
-    
+
     def setTimerCfg(self, timerCfg, channelId):
         self.sendSet('setTimerCfg', timerCfg, channelId)
-    
+
     def setGpioCfg(self, gpioCfg, channelId):
         self.sendSet('setGpioCfg', gpioCfg, channelId)
-        
+
     def getGpioCfg(self, channelId = None):
         self.sendGet('getGpioCfg', channelId)
-    
+
     def getPwmCfg(self, channelId = None):
         self.sendGet('getPwmCfg', channelId)
-    
+
     def setPwmCfg(self, pwmCfg, channelId):
         self.sendSet('setPwmCfg', pwmCfg, channelId)
-        
+
     def getTrackCfg(self):
         self.sendGet('getTrackCfg', None)
-    
+
     def setTrackCfg(self, trackCfg):
         self.sendSet('setTrackCfg', trackCfg)
-    
+
     def getCanCfg(self):
         self.sendGet('getCanCfg', None)
-    
+
     def setCanCfg(self, canCfg):
         self.sendSet('setCanCfg', canCfg)
-    
+
     def getObd2Cfg(self):
         self.sendGet('getObd2Cfg', None)
-    
+
     def setObd2Cfg(self, obd2Cfg):
         self.sendSet('setObd2Cfg', obd2Cfg)
-    
+
     def getConnectivityCfg(self):
         self.sendGet('getConnCfg', None)
-    
+
     def setConnectivityCfg(self, connCfg):
         self.sendSet('setConnCfg', connCfg)
-    
+
     def getScript(self):
         self.sendGet('getScriptCfg', None)
 
@@ -515,7 +527,7 @@ class RcpApi:
 
     def get_status(self):
         self.sendGet('getStatus', None)
-        
+
     def sequenceWriteScript(self, scriptCfg, cmdSequence):
         page = 0
         script = scriptCfg['scriptCfg']['data']
@@ -529,34 +541,34 @@ class RcpApi:
             else:
                 cmdSequence.append(RcpCmd('setScriptCfg', self.setScriptPage, script, page, SCRIPT_ADD_MODE_COMPLETE))
                 break
-        
+
     def sendRunScript(self):
         self.sendCommand({'runScript': None})
-        
+
     def runScript(self, winCallback, failCallback):
         self.executeSingle(RcpCmd('runScript', self.sendRunScript), winCallback, failCallback)
-        
+
     def setLogfileLevel(self, level, winCallback = None, failCallback = None):
         def setLogfileLevelCmd():
             self.sendCommand({'setLogfileLevel': {'level':level}})
-            
+
         if winCallback and failCallback:
             self.executeSingle(RcpCmd('logfileLevel', setLogfileLevelCmd), winCallback, failCallback)
         else:
             setLogfileLevelCmd()
-        
+
     def getLogfile(self, winCallback = None, failCallback = None):
         def getLogfileCmd():
             self.sendCommand({'getLogfile': None})
-            
+
         if winCallback and failCallback:
             self.executeSingle(RcpCmd('logfile', getLogfileCmd), winCallback, failCallback)
         else:
             getLogfileCmd()
-            
+
     def sendFlashConfig(self):
         self.sendCommand({'flashCfg': None})
-    
+
     def sequenceWriteTrackDb(self, tracksDbJson, cmdSequence):
         trackDbJson = tracksDbJson.get('trackDb')
         if trackDbJson:
@@ -573,8 +585,8 @@ class RcpApi:
 
     def addTrackDb(self, trackJson, index, mode):
         return self.sendCommand({'addTrackDb':
-                                 {'index':index, 
-                                  'mode':mode, 
+                                 {'index':index,
+                                  'mode':mode,
                                   'track': trackJson
                                   }
                                  })
@@ -590,32 +602,32 @@ class RcpApi:
 
     def getCapabilities(self):
         self.sendGet('getCapabilities')
-        
+
     def sendCalibrateImu(self):
         self.sendCommand({"calImu":1})
-        
+
     def calibrate_imu(self, winCallback, failCallback):
         cmd_sequence = []
         cmd_sequence.append(RcpCmd('calImu', self.sendCalibrateImu))
         cmd_sequence.append(RcpCmd('flashCfg', self.sendFlashConfig))
-        self._queue_multiple(cmd_sequence, 'calImu', winCallback, failCallback) 
-                
+        self._queue_multiple(cmd_sequence, 'calImu', winCallback, failCallback)
+
     def get_meta(self):
         Logger.info("RCPAPI: sending meta")
         self.sendCommand({'getMeta':None})
-        
+
     def sample(self, include_meta=False):
         if include_meta:
             self.sendCommand({'s':{'meta':1}})
         else:
             self.sendCommand({'s':0})
-            
+
     def start_auto_detect_worker(self):
         self._auto_detect_event.clear()
         t = Thread(target=self.auto_detect_worker)
         t.daemon = True
-        t.start()        
-        
+        t.start()
+
     def auto_detect_worker(self):
 
         class VersionResult(object):
@@ -624,7 +636,7 @@ class RcpApi:
         def on_ver_win(value):
             version_result.version_json = value
             version_result_event.set()
-                    
+
         while True:
             try:
                 self._auto_detect_event.wait()
@@ -634,12 +646,12 @@ class RcpApi:
                 self._auto_detect_busy.set()
                 self.sendCommandLock.acquire()
                 self.addListener("ver", on_ver_win)
-                
+
                 comms = self.comms
                 if comms and comms.isOpen():
                     comms.close()
-                
-                version_result = VersionResult()        
+
+                version_result = VersionResult()
                 version_result_event = Event()
                 version_result_event.clear()
 
@@ -648,7 +660,7 @@ class RcpApi:
                 else:
                     ports = comms.get_available_ports()
                     Logger.info('RCPAPI: Searching for device on all ports')
-        
+
                 testVer = VersionConfig()
                 for p in ports:
                     try:
@@ -669,14 +681,14 @@ class RcpApi:
                                 comms.close()
                             finally:
                                 pass
-        
+
                     except Exception as detail:
                         Logger.error('RCPAPI: Not found on ' + str(p) + " " + str(detail))
                         try:
                             comms.close()
                         finally:
                             pass
-        
+
                 if version_result.version_json != None:
                     Logger.info("RCPAPI: Found device version " + str(testVer) + " on port: " + str(comms.port))
                     self.detect_win(testVer)
@@ -694,4 +706,3 @@ class RcpApi:
                 self.removeListener("ver", on_ver_win)
                 self.sendCommandLock.release()
                 sleep(AUTODETECT_COOLOFF_TIME)
-


### PR DESCRIPTION
More than a few times I have needed a way to see what was being sent
to and from RCP.  Before this patch the only way I could do this was
to enable Trace level logging (which is not easy to do unfortunately).
But the problem with this is that if I enable Trace level debugging, I
get TONS of logs.  Metric TONS.

That is not helpful to me.  So instead I wrote this patch that will
allow me to extract out the Tx/Rx data by passing the following arg

./main.py -- --print_tx_rx