### PR TITLE
use locks to prevent dictionary contention (IOW a different thread pu…

### DIFF
--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -65,7 +65,12 @@ class DataBus(object):
         This should be called when the channel information has changed
         """
         # update channel metadata
-        with self.channel_metas as cm:
+        with self.channel_metas as cm, self.channel_data as cd:
+            # clear our list of channel data values, in case channels
+            # were removed on this metadata update
+            cd.clear()
+
+            # clear and reload our channel metas
             cm.clear()
             for meta in metas.channel_metas:
                 cm[meta.name] = meta
@@ -74,10 +79,6 @@ class DataBus(object):
             for f in self.data_filters:
                 self._update_datafilter_meta(f)
 
-        # clear our list of channel data values, in case channels
-        # were removed on this metadata update
-        with self.channel_data as cd:
-            cd.clear()
 
         self.meta_updated = True
         self.rcp_meta_read = True

--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -1,7 +1,7 @@
 from kivy.clock import Clock
 from time import sleep
 from kivy.logger import Logger
-from threading import Thread, Event
+from threading import Thread, Event, Lock
 from autosportlabs.racecapture.data.channels import ChannelMeta
 from autosportlabs.racecapture.data.sampledata import Sample, SampleMetaException, ChannelMetaCollection
 from autosportlabs.racecapture.databus.filter.bestlapfilter import BestLapFilter
@@ -9,7 +9,7 @@ from autosportlabs.racecapture.databus.filter.laptimedeltafilter import LaptimeD
 from autosportlabs.util.threadutil import safe_thread_exit
 
 
-DEFAULT_DATABUS_UPDATE_INTERVAL = 0.02 #50Hz UI update rate
+DEFAULT_DATABUS_UPDATE_INTERVAL = 0.02  # 50Hz UI update rate
 
 class DataBusFactory(object):
     def create_standard_databus(self, system_channels):
@@ -17,7 +17,7 @@ class DataBusFactory(object):
         databus.add_data_filter(BestLapFilter(system_channels))
         databus.add_data_filter(LaptimeDeltaFilter(system_channels))
         return databus
-    
+
 class DataBus(object):
     """Central hub for current sample data. Receives data from DataBusPump
     Also contains the periodic updater for listeners. Updates occur in the UI thread via Clock.schedule_interval
@@ -40,11 +40,12 @@ class DataBus(object):
     sample_listeners = []
     _polling = False
     rcp_meta_read = False
+    channel_data_lock = Lock()
 
     def __init__(self, **kwargs):
         super(DataBus, self).__init__(**kwargs)
 
-    def start_update(self, interval = DEFAULT_DATABUS_UPDATE_INTERVAL):
+    def start_update(self, interval=DEFAULT_DATABUS_UPDATE_INTERVAL):
         if self._polling:
             return
 
@@ -64,14 +65,19 @@ class DataBus(object):
         """update channel metadata information
         This should be called when the channel information has changed
         """
-        self.channel_metas.clear()
-        for meta in metas.channel_metas:
-            self.channel_metas[meta.name] = meta
-            
-        #add channel meta for existing filters
-        for f in self.data_filters:
-            self._update_datafilter_meta(f)
-                
+        # update
+        with self.channel_data_lock:
+            self.channel_metas.clear()
+            for meta in metas.channel_metas:
+                self.channel_metas[meta.name] = meta
+
+            # add channel meta for existing filters
+            for f in self.data_filters:
+                self._update_datafilter_meta(f)
+            # clear our list of channel data values, in case channels
+            # were removed on this metadata update
+            self.channel_data.clear()
+
         self.meta_updated = True
         self.rcp_meta_read = True
 
@@ -81,29 +87,29 @@ class DataBus(object):
     def update_samples(self, sample):
         """Update channel data with new samples
         """
-        for sample_item in sample.samples:
-            channel = sample_item.channelMeta.name
-            value = sample_item.value
-            self.channel_data[channel] = value
+        with self.channel_data_lock:
+            for sample_item in sample.samples:
+                channel = sample_item.channelMeta.name
+                value = sample_item.value
+                self.channel_data[channel] = value
 
-        #apply filters to updated data
-        for f in self.data_filters:
-            f.filter(self.channel_data)
+            # apply filters to updated data
+            for f in self.data_filters:
+                f.filter(self.channel_data)
 
     def notify_listeners(self, dt):
-        sample_data = {}
 
-        if self.meta_updated:
-            self.notify_meta_listeners(self.channel_metas)
-            self.meta_updated = False
+        with self.channel_data_lock:
+            if self.meta_updated:
+                self.notify_meta_listeners(self.channel_metas)
+                self.meta_updated = False
 
-        for channel,value in self.channel_data.iteritems():
-            self.notify_channel_listeners(channel, value)
-            sample_data[channel] = value
+            for channel, value in self.channel_data.iteritems():
+                self.notify_channel_listeners(channel, value)
 
-        for listener in self.sample_listeners:
-            listener(sample_data)
-                
+            for listener in self.sample_listeners:
+                listener(self.channel_data)
+
     def notify_channel_listeners(self, channel, value):
         listeners = self.channel_listeners.get(str(channel))
         if listeners:
@@ -132,25 +138,25 @@ class DataBus(object):
 
     def add_sample_listener(self, callback):
         self.sample_listeners.append(callback)
-                    
+
     def addMetaListener(self, callback):
         self.meta_listeners.append(callback)
 
     def add_data_filter(self, datafilter):
         self.data_filters.append(datafilter)
         self._update_datafilter_meta(datafilter)
-        
+
     def getMeta(self):
         return self.channel_metas
 
     def getData(self, channel):
         return self.channel_data[channel]
 
-SAMPLE_POLL_TEST_TIMEOUT       = 3.0
-SAMPLE_POLL_INTERVAL_TIMEOUT   = 0.02 #50Hz polling
-SAMPLE_POLL_EVENT_TIMEOUT      = 1.0
+SAMPLE_POLL_TEST_TIMEOUT = 3.0
+SAMPLE_POLL_INTERVAL_TIMEOUT = 0.02  # 50Hz polling
+SAMPLE_POLL_EVENT_TIMEOUT = 1.0
 SAMPLE_POLL_EXCEPTION_RECOVERY = 10.0
-SAMPLES_TO_WAIT_FOR_META       = 5.0
+SAMPLES_TO_WAIT_FOR_META = 5.0
 
 class DataBusPump(object):
     """Responsible for dispatching raw JSON API messages into a format the DataBus can consume.
@@ -164,7 +170,7 @@ class DataBusPump(object):
     _running = Event()
     _sample_thread = None
     _meta_is_stale_counter = 0
-    
+
     def __init__(self, **kwargs):
         super(DataBusPump, self).__init__(**kwargs)
 
@@ -172,16 +178,16 @@ class DataBusPump(object):
         if self._sample_thread == None:
             self._rc_api = rc_api
             self._data_bus = data_bus
-    
+
             rc_api.addListener('s', self.on_sample)
             rc_api.addListener('meta', self.on_meta)
-            
+
             self._running.set()
             self._sample_thread = Thread(target=self.sample_worker)
             self._sample_thread.daemon = True
             self._sample_thread.start()
         else:
-            #we're already running, refresh channel meta data
+            # we're already running, refresh channel meta data
             self.meta_is_stale()
 
     def on_meta(self, meta_json):
@@ -189,18 +195,18 @@ class DataBusPump(object):
         metas.fromJson(meta_json.get('meta'))
         self._data_bus.update_channel_meta(metas)
         self._meta_is_stale_counter = 0
-    
+
     def on_sample(self, sample_json):
         sample = self.sample
         dataBus = self._data_bus
         try:
             sample.fromJson(sample_json)
-            dataBus.update_samples(sample)
             if sample.updated_meta:
                 dataBus.update_channel_meta(sample.metas)
+            dataBus.update_samples(sample)
             self._sample_event.set()
         except SampleMetaException:
-            #this is to prevent repeated sample meta requests
+            # this is to prevent repeated sample meta requests
             self._request_meta_handler()
 
     def _request_meta_handler(self):
@@ -210,21 +216,21 @@ class DataBusPump(object):
                 self.request_meta()
             else:
                 self._meta_is_stale_counter -= 1
-        
+
     def stopDataPump(self):
         self._running.clear()
         self._sample_thread.join()
 
     def meta_is_stale(self):
         self.request_meta()
-        
+
     def request_meta(self):
         self._rc_api.get_meta()
-    
+
     def sample_worker(self):
         rc_api = self._rc_api
         sample_event = self._sample_event
-        
+
         Logger.info('DataBusPump: DataBus Sampler Starting')
         sample_event.clear()
         if sample_event.wait(SAMPLE_POLL_TEST_TIMEOUT) == True:
@@ -233,9 +239,9 @@ class DataBusPump(object):
             Logger.info('DataBusPump: Synchronous sampling mode enabled')
             while self._running.is_set():
                 try:
-                    #the timeout here is designed to be longer than the streaming rate of 
-                    #RaceCapture. If we don't get an asynchronous sample, then we will timeout
-                    #and request a sample anyway.
+                    # the timeout here is designed to be longer than the streaming rate of
+                    # RaceCapture. If we don't get an asynchronous sample, then we will timeout
+                    # and request a sample anyway.
                     rc_api.sample()
                     sample_event.wait(SAMPLE_POLL_EVENT_TIMEOUT)
                     sample_event.clear()
@@ -245,7 +251,7 @@ class DataBusPump(object):
                     Logger.error('DataBusPump: Exception in sample_worker: ' + str(e))
                 finally:
                     sample_event.clear()
-                
+
         Logger.info('DataBusPump: DataBus Sampler Exiting')
         safe_thread_exit()
 

--- a/autosportlabs/racecapture/views/dashboard/rawchannelview.py
+++ b/autosportlabs/racecapture/views/dashboard/rawchannelview.py
@@ -14,47 +14,48 @@ from kivy.graphics import Color, Rectangle
 Builder.load_file('autosportlabs/racecapture/views/dashboard/rawchannelview.kv')
 
 NO_DATA_MSG = 'No Data'
-DATA_MSG    = ''
+DATA_MSG = ''
 
 RAW_GRID_BGCOLOR_1 = [0  , 0  , 0  , 1.0]
 RAW_GRID_BGCOLOR_2 = [0.1, 0.1, 0.1, 1.0]
-RAW_NORMAL_COLOR   = [0.0, 1.0, 0.0, 1.0]
+RAW_NORMAL_COLOR = [0.0, 1.0, 0.0, 1.0]
 
 class RawGauge(DigitalGauge):
     backgroundColor = ObjectProperty(RAW_GRID_BGCOLOR_1)
 
     def __init__(self, **kwargs):
         super(RawGauge  , self).__init__(**kwargs)
-        self.normal_color =  RAW_NORMAL_COLOR
-        
+        self.normal_color = RAW_NORMAL_COLOR
+
     def update_colors(self):
         color = self.select_alert_color()
         self.valueView.color = color
-        
+
 class RawChannelView(Screen):
     _gauges = {}
     _grid = None
     _bgCurrent = RAW_GRID_BGCOLOR_1
     _databus = None
     settings = None
-    
+
     def __init__(self, databus, settings, **kwargs):
         super(RawChannelView, self).__init__(**kwargs)
         self._databus = databus
         self.settings = settings
         self.initScreen()
-    
+
     @property
     def _gridView(self):
         if self._grid == None:
             self._grid = kvFind(self, 'rcid', 'grid')
         return self._grid
-        
-    def on_meta(self, channelMetas):
+
+    def on_meta(self, channel_metas):
         self._clearGauges()
-        for channel,channelMeta in channelMetas.iteritems():
-            self._addGauge(channelMeta)
-            
+        with channel_metas as cm:
+            for channel_meta in cm.itervalues():
+                self._addGauge(channel_meta)
+
     def initScreen(self):
         dataBus = self._databus
         dataBus.addMetaListener(self.on_meta)
@@ -66,21 +67,21 @@ class RawChannelView(Screen):
     def _enableNoDataStatus(self, enabled):
         statusView = kvFind(self, 'rcid', 'statusMsg')
         statusView.text = NO_DATA_MSG if enabled else DATA_MSG
-        
+
     def _clearGauges(self):
         gridView = self._gridView
         gridView.clear_widgets()
         self._enableNoDataStatus(True)
-        
+
     def _addGauge(self, channelMeta):
         channel = channelMeta.name
         gauge = RawGauge(rcid=None, dataBus=self._databus, settings=self.settings, targetchannel=channel)
         gridView = self._gridView
         gauge.precision = channelMeta.precision
-        
+
         if len(gridView.children) % 3 == 0:
             self._bgCurrent = RAW_GRID_BGCOLOR_2 if self._bgCurrent == RAW_GRID_BGCOLOR_1 else RAW_GRID_BGCOLOR_1
-            
+
         gauge.backgroundColor = self._bgCurrent
         gridView.add_widget(gauge)
         self._gauges[channel] = gauge

--- a/autosportlabs/telemetry/telemetryconnection.py
+++ b/autosportlabs/telemetry/telemetryconnection.py
@@ -470,23 +470,22 @@ class TelemetryConnection(asynchat.async_chat):
             bitmask_index = 0
             data = []
 
-            with self._sample_data as sd:
-                with self._channel_metas as cm:
-                    bitmasks_needed = int(max(0, math.floor((len(cm) - 1) / 32)) + 1)
-                    for x in range(0, bitmasks_needed):
-                        bitmasks.append(0)
+            with self._sample_data as sd, self._channel_metas as cm:
+                bitmasks_needed = int(max(0, math.floor((len(cm) - 1) / 32)) + 1)
+                for x in range(0, bitmasks_needed):
+                    bitmasks.append(0)
 
-                    for channel_name, value in cm.iteritems():
-                        if channel_bit_position > 31:
-                            bitmask_index += 1
-                            channel_bit_position = 0
+                for channel_name, value in cm.iteritems():
+                    if channel_bit_position > 31:
+                        bitmask_index += 1
+                        channel_bit_position = 0
 
-                        value = sd.get(channel_name)
-                        if value is not None:
-                            bitmasks[bitmask_index] = bitmasks[bitmask_index] | (1 << channel_bit_position)
-                            data.append(value)
+                    value = sd.get(channel_name)
+                    if value is not None:
+                        bitmasks[bitmask_index] = bitmasks[bitmask_index] | (1 << channel_bit_position)
+                        data.append(value)
 
-                        channel_bit_position += 1
+                    channel_bit_position += 1
 
             for bitmask in bitmasks:
                 data.append(bitmask)

--- a/autosportlabs/telemetry/telemetryconnection.py
+++ b/autosportlabs/telemetry/telemetryconnection.py
@@ -124,7 +124,7 @@ class TelemetryManager(EventDispatcher):
 
     # Starts connection, checks to see if requirements are met
     def start(self):
-        Logger.info("TelemetryManager: start() telemetry_enabled: " + str(self.telemetry_enabled) + " cell_enabled: "+ str(self.cell_enabled))
+        Logger.info("TelemetryManager: start() telemetry_enabled: " + str(self.telemetry_enabled) + " cell_enabled: " + str(self.cell_enabled))
         self._auth_failed = False
 
         if self.telemetry_enabled and not self.cell_enabled and self.device_id != "":
@@ -170,7 +170,7 @@ class TelemetryManager(EventDispatcher):
     # Status function that receives events from TelemetryConnection thread
     # Bubbles up events into main app
     def status(self, status, msg, status_code):
-        Logger.debug("TelemetryManager: got telemetry status: " + str(status) + " message: " + str(msg) + " code: "+ str(status_code))
+        Logger.debug("TelemetryManager: got telemetry status: " + str(status) + " message: " + str(msg) + " code: " + str(status_code))
         if status_code == TelemetryConnection.STATUS_CONNECTED:
             self.dispatch('on_connected', msg)
         elif status_code == TelemetryConnection.STATUS_AUTHORIZED:
@@ -237,7 +237,7 @@ class TelemetryConnection(asynchat.async_chat):
 
     SAMPLE_INTERVAL = 0.1
 
-    def __init__(self, host, port, device_id, channels, data_bus, update_status_cb):
+    def __init__(self, host, port, device_id, channel_metas, data_bus, update_status_cb):
         asynchat.async_chat.__init__(self)
 
         self.status = self.STATUS_UNINITIALIZED
@@ -252,7 +252,7 @@ class TelemetryConnection(asynchat.async_chat):
         self.authorized = False
         self.meta_sent = False
 
-        self._channel_data = channels
+        self._channel_metas = channel_metas
         self._sample_data = None
 
         self.host = host
@@ -273,7 +273,7 @@ class TelemetryConnection(asynchat.async_chat):
     def _on_meta(self, meta):
         Logger.debug("TelemetryConnection: got new meta")
         if self.authorized:
-            self._channel_data = meta
+            self._channel_metas = meta
 
             self._running.clear()
             try:
@@ -354,7 +354,7 @@ class TelemetryConnection(asynchat.async_chat):
         t, v, trace = sys.exc_info()
 
         tbinfo = []
-        if not trace: # Must have a traceback
+        if not trace:  # Must have a traceback
             raise AssertionError("traceback does not exist")
         while trace:
             tbinfo.append((
@@ -379,7 +379,7 @@ class TelemetryConnection(asynchat.async_chat):
                 Logger.error("TelemetryConnection: timeout connecting")
                 self._update_status("error", "Timeout connecting", self.ERROR_TIMEOUT)
             else:
-                Logger.error("TelemetryConnection: unknown error connecting " + str(t) + " " +str(v))
+                Logger.error("TelemetryConnection: unknown error connecting " + str(t) + " " + str(v))
                 self._update_status("error", "Unknown error", self.ERROR_UNKNOWN)
             self.end()
         else:
@@ -446,15 +446,16 @@ class TelemetryConnection(asynchat.async_chat):
         msg = {"s":{"meta":[]}}
         meta = []
 
-        for channel_name, channel_config in self._channel_data.iteritems():
-            channel = {
-                "nm": channel_config.name,
-                "ut": channel_config.units,
-                "sr": channel_config.sampleRate,
-                "min": channel_config.min,
-                "max": channel_config.max
-            }
-            meta.append(channel)
+        with self._channel_metas as cm:
+            for channel_config in cm.itervalues():
+                channel = {
+                    "nm": channel_config.name,
+                    "ut": channel_config.units,
+                    "sr": channel_config.sampleRate,
+                    "min": channel_config.min,
+                    "max": channel_config.max
+                }
+                meta.append(channel)
 
         msg["s"]["meta"] = meta
         msg_json = json.dumps(msg)
@@ -465,26 +466,27 @@ class TelemetryConnection(asynchat.async_chat):
         if self._sample_data is not None:
             update = {"s": {"d": None}}
             bitmasks = []
-            bitmasks_needed = int(max(0, math.floor((len(self._channel_data) - 1) / 32)) + 1)
             channel_bit_position = 0
             bitmask_index = 0
-
             data = []
 
-            for x in range(0, bitmasks_needed):
-                bitmasks.append(0)
+            with self._sample_data as sd:
+                with self._channel_metas as cm:
+                    bitmasks_needed = int(max(0, math.floor((len(cm) - 1) / 32)) + 1)
+                    for x in range(0, bitmasks_needed):
+                        bitmasks.append(0)
 
-            for channel_name, value in self._channel_data.iteritems():
-                if channel_bit_position > 31:
-                    bitmask_index += 1
-                    channel_bit_position = 0
+                    for channel_name, value in cm.iteritems():
+                        if channel_bit_position > 31:
+                            bitmask_index += 1
+                            channel_bit_position = 0
 
-                if channel_name in self._sample_data:
-                    value = self._sample_data[channel_name]
-                    bitmasks[bitmask_index] = bitmasks[bitmask_index] | (1 << channel_bit_position)
-                    data.append(value)
+                        value = sd.get(channel_name)
+                        if value is not None:
+                            bitmasks[bitmask_index] = bitmasks[bitmask_index] | (1 << channel_bit_position)
+                            data.append(value)
 
-                channel_bit_position += 1
+                        channel_bit_position += 1
 
             for bitmask in bitmasks:
                 data.append(bitmask)

--- a/autosportlabs/util/threadutil.py
+++ b/autosportlabs/util/threadutil.py
@@ -1,3 +1,4 @@
+from threading import RLock
 from kivy import platform
 __all__ = ('safe_thread_exit')
 
@@ -7,5 +8,17 @@ if platform == 'android':
 
 def safe_thread_exit():
     if platform == 'android':
-        jnius.detach() #detach the current thread from pyjnius, else hard crash occurs
-        
+        jnius.detach()  # detach the current thread from pyjnius, else hard crash occurs
+
+
+class ThreadSafeDict(dict) :
+    def __init__(self, * p_arg, ** n_arg) :
+        dict.__init__(self, * p_arg, ** n_arg)
+        self._lock = RLock()
+
+    def __enter__(self) :
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, type, value, traceback) :
+        self._lock.release()


### PR DESCRIPTION
Sentry reported periodic exceptions where the channel_data dict was getting stepped on by a different thread. This puts a Lock (mutex) around accessing that dict to prevent errors from happening. 

Also, resets channel_data dict to {} if new metadata was received, in case channels were removed from the stream (due to an RCP config change).

Resolves #852 

(has other code formatting changes due to an automatic code formatting tools in the editor, sorry for the noise)