### PR TITLE
when requesting data async, ensure we call back on th UI thread

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+==1.4.3==
+* Resolves sporadic issue where rapid lap selection may result in internal errors
+
 ==1.4.2==
 * Connect to the first RaceCapture device it can detect, regardless of the name provided
 * Improve analysis data query performance; don't block user interface for long operations; show spinner

--- a/autosportlabs/racecapture/views/analysis/analysisdata.py
+++ b/autosportlabs/racecapture/views/analysis/analysisdata.py
@@ -21,6 +21,7 @@ from autosportlabs.racecapture.datastore import DataStore, Filter, timing
 from autosportlabs.racecapture.geo.geopoint import GeoPoint
 from threading import Thread
 from kivy.logger import Logger
+from kivy.clock import Clock
 import Queue
 
 class ChannelStats(object):
@@ -116,7 +117,7 @@ class CachingAnalysisDatastore(DataStore):
         if len(channels_to_query) > 0:
             channel_d = self._query_channel_data(params.source_ref, channels_to_query, channel_data)
 
-        params.callback(channel_data)
+        Clock.schedule_once(lambda dt: params.callback(channel_data))
 
     def _get_location_data(self, params):
         '''
@@ -139,7 +140,9 @@ class CachingAnalysisDatastore(DataStore):
                 lon = r[2]
                 cache.append(GeoPoint.fromPoint(lat, lon))
             self._session_location_cache[source_key]=cache
-        params.callback(cache)
+
+        Clock.schedule_once(lambda dt: params.callback(cache))
+
         
     def _get_channel_data_worker(self):
         '''


### PR DESCRIPTION
else sadness may ensue. scheduling on the UI thread ensures resources are accessed in the proper order.

resolves #871

