### PR TITLE
Upgrade path for track ids being returned as integers instead of strings

### DIFF
--- a/autosportlabs/racecapture/settings/prefs.py
+++ b/autosportlabs/racecapture/settings/prefs.py
@@ -97,6 +97,7 @@ class UserPrefs(EventDispatcher):
         self.config.setdefault('preferences', 'firmware_dir', default_user_files_dir )
         self.config.setdefault('preferences', 'import_datalog_dir', default_user_files_dir )
         self.config.setdefault('preferences', 'first_time_setup', True)
+        self.config.setdefault('preferences', 'integer_map_ids', False)
         self.config.setdefault('preferences', 'send_telemetry', False)
         self.config.setdefault('preferences', 'last_dash_screen', 'gaugeView')
         self.config.setdefault('preferences', 'global_help', True)

--- a/autosportlabs/racecapture/tracks/trackmanager.py
+++ b/autosportlabs/racecapture/tracks/trackmanager.py
@@ -7,6 +7,7 @@ import logging
 from threading import Thread, Lock
 import urllib2
 import os
+import glob
 import traceback
 from autosportlabs.racecapture.geo.geopoint import GeoPoint, Region
 from kivy.logger import Logger
@@ -285,7 +286,7 @@ class TrackManager:
         return venues_list
 
     def download_track(self, track_id):
-        track_url = self.RCP_VENUE_URL + '/' + track_id
+        track_url = self.RCP_VENUE_URL + '/' + str(track_id)
         response = self.load_json(track_url)
         track_map = TrackMap()
         try:
@@ -296,7 +297,7 @@ class TrackManager:
             return None
         
     def save_track(self, track):
-        path = self.tracks_user_dir + '/' + track.track_id + '.json'
+        path = self.tracks_user_dir + '/' + str(track.track_id) + '.json'
         track_json_string = json.dumps(track.to_dict(), sort_keys=True, indent=2, separators=(',', ': '))
         with open(path, 'w') as text_file:
             text_file.write(track_json_string)
@@ -419,6 +420,14 @@ class TrackManager:
                                 progress_cb(count=count, total=track_count, message=updated_track.name)
                     else:
                         progress_cb(count=count, total=track_count)
+
+    def delete_all_local_tracks(self):
+        """WARNING: this will delete all local tracks!!!
+        """
+        files = glob.glob(self.tracks_user_dir + '/*')
+        for f in files:
+            os.remove(f)
+        self.tracks.clear()
 
 
 class MissingKeyException(Exception):

--- a/main.py
+++ b/main.py
@@ -405,8 +405,23 @@ class RaceCaptureApp(App):
         Clock.schedule_once(lambda dt: self.init_data())
         Clock.schedule_once(lambda dt: self.init_rc_comms())
         Clock.schedule_once(lambda dt: self.show_startup_view())
+
+        #Ugly hack to handle track ids changing from strings to integers
+        if self.settings.userPrefs.get_pref('preferences', 'integer_map_ids') == 'False' and self.settings.userPrefs.get_pref('preferences', 'first_time_setup') == 'False':
+            Clock.schedule_once(lambda dt: self.refresh_tracks(), 0.5)
+
         self.check_first_time_setup()
 
+    def refresh_tracks(self):
+        popup = None
+        def _on_answer(instance, answer):
+            popup.dismiss()
+            if answer:
+                self.showMainView('tracks')
+                self.trackManager.delete_all_local_tracks()
+                self.settings.userPrefs.set_pref('preferences', 'integer_map_ids', True)
+                Clock.schedule_once(lambda dt: self.mainViews['tracks'].check_for_update(), 0.5)
+        popup = confirmPopup('Race Tracks', 'RaceCapture needs to refresh all tracks in order to properly configure RaceCapture/Pro.', _on_answer)
 
     def check_first_time_setup(self):
         if self.settings.userPrefs.get_pref('preferences', 'first_time_setup') == 'True':


### PR DESCRIPTION
So, someone changed the RCL api to return integers instead of strings for track ids, which breaks all sorts of things in the app. 

This PR:

1. Detects we haven't fixed this issue using a preference that defaults to False, then is set to True once tracks are updated. 
2. Prompts the user they need to update their track maps 
3. Refresh tracks to use the new integer id

To test, make a backup of the venues folder in the app data dir first (these are the old string based ids). Put it back and update the preferences.ini file and set `integer_map_ids` to `False` to repeat the test.