### PR TITLE
if lap timing is off, don't create the bestlap / lapdelta channels

### DIFF
--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -55,7 +55,8 @@ class DataBus(object):
         self._polling = False
 
     def _update_datafilter_meta(self, datafilter):
-        metas = datafilter.get_channel_meta()
+        channel_metas = self.channel_metas
+        metas = datafilter.get_channel_meta(channel_metas)
         with self.channel_metas as cm:
             for channel, meta in metas.iteritems():
                 cm[channel] = meta

--- a/autosportlabs/racecapture/databus/filter/bestlapfilter.py
+++ b/autosportlabs/racecapture/databus/filter/bestlapfilter.py
@@ -3,20 +3,23 @@
 class BestLapFilter(object):
     """Update BestLap if laptime is present and is faster than the current best"""
     BEST_LAPTIME_KEY = 'BestLap'
-    LAST_LAPTIME_KEY = 'LapTime'
+    LAPTIME_KEY = 'LapTime'
     best_laptime = 0
     best_laptime_meta = None
     def __init__(self, system_channels):
         self.best_laptime_meta = system_channels.findChannelMeta(BestLapFilter.BEST_LAPTIME_KEY)
         
-    def get_channel_meta(self):
-        return {BestLapFilter.BEST_LAPTIME_KEY: self.best_laptime_meta}
+    def get_channel_meta(self, channel_meta):
+        metas = {}
+        if channel_meta.get(self.LAPTIME_KEY):
+            metas[BestLapFilter.BEST_LAPTIME_KEY] = self.best_laptime_meta
+        return metas
     
     def reset(self):
         self.best_laptime = 0
          
     def filter(self, channel_data):
-        laptime = channel_data.get(self.LAST_LAPTIME_KEY)
+        laptime = channel_data.get(self.LAPTIME_KEY)
         if laptime is not None and laptime > 0:
             current_best_laptime = self.best_laptime
             if current_best_laptime == 0 or laptime < current_best_laptime: 

--- a/autosportlabs/racecapture/databus/filter/laptimedeltafilter.py
+++ b/autosportlabs/racecapture/databus/filter/laptimedeltafilter.py
@@ -19,8 +19,11 @@ class LaptimeDeltaFilter(object):
     def reset(self):
         pass
     
-    def get_channel_meta(self):
-        return {LaptimeDeltaFilter.LAP_DELTA_KEY: self.lap_delta_meta}
+    def get_channel_meta(self, channel_meta):
+        metas = {}
+        if channel_meta.get(self.LAPTIME_KEY):
+            metas[LaptimeDeltaFilter.LAP_DELTA_KEY] = self.lap_delta_meta
+        return metas
         
     def filter(self, channel_data):
         laptime = channel_data.get(LaptimeDeltaFilter.LAPTIME_KEY)


### PR DESCRIPTION
Addresses #884 

Introspect incoming channel meta to see if laptime is present; if so; add the related best lap and lap delta filter channels