### PR TITLE
Re-select track map as appropriate

### DIFF
--- a/autosportlabs/racecapture/tracks/trackmanager.py
+++ b/autosportlabs/racecapture/tracks/trackmanager.py
@@ -35,6 +35,11 @@ class TrackMap:
         self.country_code = None
         self.configuration = None
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.track_id == other.track_id
+        return False
+
     @property
     def centerpoint(self):
         if len(self.map_points) > 0:

--- a/autosportlabs/racecapture/views/analysis/analysismap.py
+++ b/autosportlabs/racecapture/views/analysis/analysismap.py
@@ -195,7 +195,6 @@ class AnalysisMap(AnalysisWidget):
             self.ids.track_name.text = ''
             self.ids.track.setTrackPoints([])
         self.track = track
-        return track
 
     def _customized(self, instance, values):
         self._update_trackmap(values)
@@ -256,7 +255,10 @@ class AnalysisMap(AnalysisWidget):
         '''
         point = GeoPoint.fromPoint(latitude, longitude)
         track = self.track_manager.find_nearby_track(point)
-        return self._select_track(track)
+        if self.track != track:
+            #only update the trackmap if it's changing
+            self._select_track(track)
+        return track
 
     def remove_reference_mark(self, source):
         self.ids.track.remove_marker(source)

--- a/autosportlabs/racecapture/views/analysis/analysismap.py
+++ b/autosportlabs/racecapture/views/analysis/analysismap.py
@@ -250,13 +250,13 @@ class AnalysisMap(AnalysisWidget):
         :param latitude
         :type  latitude float
         :param longitude
-        :type longitude float 
+        :type longitude float
+        :returns the selected track
+        :type Track 
         '''
-        if self.track_manager:
-            point = GeoPoint.fromPoint(latitude, longitude)
-            track = self.track_manager.find_nearby_track(point)
-            return self._select_track(track)
-        return None
+        point = GeoPoint.fromPoint(latitude, longitude)
+        track = self.track_manager.find_nearby_track(point)
+        return self._select_track(track)
 
     def remove_reference_mark(self, source):
         self.ids.track.remove_marker(source)

--- a/autosportlabs/racecapture/views/analysis/analysismap.py
+++ b/autosportlabs/racecapture/views/analysis/analysismap.py
@@ -195,6 +195,7 @@ class AnalysisMap(AnalysisWidget):
             self.ids.track_name.text = ''
             self.ids.track.setTrackPoints([])
         self.track = track
+        return track
 
     def _customized(self, instance, values):
         self._update_trackmap(values)
@@ -254,7 +255,8 @@ class AnalysisMap(AnalysisWidget):
         if self.track_manager:
             point = GeoPoint.fromPoint(latitude, longitude)
             track = self.track_manager.find_nearby_track(point)
-            self._select_track(track)
+            return self._select_track(track)
+        return None
 
     def remove_reference_mark(self, source):
         self.ids.track.remove_marker(source)

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -114,12 +114,11 @@ class AnalysisView(Screen):
         lat_avg, lon_avg = self._datastore.get_location_center([session])
         new_track = analysis_map.select_map(lat_avg, lon_avg)
 
-        if current_track is not None:
-            if current_track.track_id != new_track.track_id:
-                #if a new track is selected, then
-                #unselect all laps for all other sessions
-                sessions_view = self.ids.sessions_view
-                sessions_view.deselect_other_laps(session)
+        if current_track != new_track:
+            #if a new track is selected, then
+            #unselect all laps for all other sessions
+            sessions_view = self.ids.sessions_view
+            sessions_view.deselect_other_laps(session)
         
 
     def open_datastore(self):

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -109,9 +109,18 @@ class AnalysisView(Screen):
 
     def _sync_analysis_map(self, session):
         analysis_map = self.ids.analysismap
-        if not analysis_map.track:
-            lat_avg, lon_avg = self._datastore.get_location_center([session])
-            analysis_map.select_map(lat_avg, lon_avg)
+        current_track = analysis_map.track
+
+        lat_avg, lon_avg = self._datastore.get_location_center([session])
+        new_track = analysis_map.select_map(lat_avg, lon_avg)
+
+        if current_track is not None:
+            if current_track.track_id != new_track.track_id:
+                #if a new track is selected, then
+                #unselect all laps for all other sessions
+                sessions_view = self.ids.sessions_view
+                sessions_view.deselect_other_laps(session)
+        
 
     def open_datastore(self):
         pass

--- a/autosportlabs/racecapture/views/analysis/sessionbrowser.py
+++ b/autosportlabs/racecapture/views/analysis/sessionbrowser.py
@@ -269,7 +269,7 @@ class SessionBrowser(AnchorLayout):
         '''
         Deselect all laps except from the session specified
         :param session id
-        :type integer
+        :type session integer
         '''
         source_refs = []
         for instance in self.selected_laps.itervalues():
@@ -281,7 +281,7 @@ class SessionBrowser(AnchorLayout):
         '''
         Deselect all laps specified in the list of source refs
         :param source_refs the list of source_refs
-        :type array 
+        :type source_refs array 
         '''
         for source_ref in source_refs:
             source_key = str(source_ref)

--- a/autosportlabs/racecapture/views/analysis/sessionbrowser.py
+++ b/autosportlabs/racecapture/views/analysis/sessionbrowser.py
@@ -272,6 +272,19 @@ class SessionBrowser(AnchorLayout):
             lap_instance.state = 'down' if selected else 'normal'
             self._notify_lap_selected(source_ref, True)
 
+
+    def deselect_other_laps(self, session):
+        '''
+        Deselect all laps except from the session specified
+        :param session id
+        :type integer
+        '''
+        source_refs = []
+        for instance in self.selected_laps.itervalues():
+            if instance.session != session:
+                source_refs.append(SourceRef(instance.lap, instance.session))
+        self.deselect_laps(source_refs)
+        
     def deselect_laps(self, source_refs):
         '''
         Deselect all laps specified in the list of source refs
@@ -282,5 +295,6 @@ class SessionBrowser(AnchorLayout):
             source_key = str(source_ref)
             instance = self.selected_laps.get(source_key)
             if instance:
+                instance.state = 'normal'
                 self.selected_laps.pop(source_key, None)
                 self._notify_lap_selected(source_ref, False)


### PR DESCRIPTION
If we select a a lap from a session at at different track, clear existing lap selections. 

Note, the predecessor to this PR is https://github.com/autosportlabs/RaceCapture_App/pull/908 - the diff will look more concise once that one is merged.

Resolves #800 
