### PR TITLE
switch lap querying to use CurrentLap and ElapsedTime throughout

### DIFF
--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -239,7 +239,7 @@ class DatalogChannel(object):
         return self.name
 
 class DataStore(object):
-    EXTRA_INDEX_CHANNELS = ["LapCount","CurrentLap"]    
+    EXTRA_INDEX_CHANNELS = ["CurrentLap"]    
     val_filters = ['lt', 'gt', 'eq', 'lt_eq', 'gt_eq']
     def __init__(self):
         self._channels = []

--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -139,6 +139,12 @@ class Session(object):
         self.notes = notes
         self.date = date
         
+class Lap(object):
+    def __init__(self, lap, session_id, lap_time):
+        self.lap = lap
+        self.session_id = session_id
+        self.lap_time = lap_time
+
 #Filter container class
 class Filter(object):
     def __init__(self):
@@ -233,7 +239,7 @@ class DatalogChannel(object):
         return self.name
 
 class DataStore(object):
-    EXTRA_INDEX_CHANNELS = ["LapCount"]    
+    EXTRA_INDEX_CHANNELS = ["LapCount","CurrentLap"]    
     val_filters = ['lt', 'gt', 'eq', 'lt_eq', 'gt_eq']
     def __init__(self):
         self._channels = []
@@ -864,6 +870,7 @@ class DataStore(object):
         #Now add the session filter to the select statement
         sel_st += ses_st
 
+        Logger.debug('[datastore] Query execute: {}'.format(sel_st))
         c = self._conn.cursor()
         c.execute(sel_st)
 
@@ -892,7 +899,31 @@ class DataStore(object):
             sessions.append(Session(session_id=row[0], name=row[1], notes=row[2], date=row[3]))
         
         return sessions
-    
+
+    def get_laps(self, session_id):
+        '''
+        Fetches a list of lap information for the specified session id
+        :param session_id the session id
+        :type session_id int
+        :returns list of Lap objects
+        :type list 
+        '''        
+        laps = []
+        c = self._conn.cursor()
+        for row in c.execute('''SELECT DISTINCT sample.session_id AS session_id, 
+                                datapoint.CurrentLap AS CurrentLap, 
+                                max(datapoint.ElapsedTime) AS ElapsedTime
+                                FROM sample
+                                JOIN datapoint ON datapoint.sample_id=sample.id
+                                WHERE datapoint.CurrentLap > 0
+                                AND sample.session_id = ?
+                                GROUP BY CurrentLap, session_id
+                                ORDER BY datapoint.CurrentLap ASC;''',
+                                (session_id,)):
+            laps.append(Lap(session_id=row[0], lap=row[1], lap_time=row[2]))
+        return laps
+                
+        
     def update_session(self, session):
         self._conn.execute("""UPDATE session SET name=?, notes=?, date=? WHERE id=?;""", (session.name, session.notes, unix_time(datetime.datetime.now()), session.session_id ,))
         self._conn.commit()

--- a/autosportlabs/racecapture/views/analysis/analysisdata.py
+++ b/autosportlabs/racecapture/views/analysis/analysisdata.py
@@ -83,7 +83,7 @@ class CachingAnalysisDatastore(DataStore):
         Logger.info('CachingAnalysisDatastore: querying {} {}'.format(source_ref, channels))
         lap = source_ref.lap
         session = source_ref.session
-        f = Filter().eq('LapCount', lap)
+        f = Filter().eq('CurrentLap', lap)
         dataset = self.query(sessions=[session], channels=channels, data_filter=f)
         records = dataset.fetch_records()
 
@@ -129,7 +129,7 @@ class CachingAnalysisDatastore(DataStore):
         if cache == None:
             session = source_ref.session
             lap = source_ref.lap
-            f = Filter().neq('Latitude', 0).and_().neq('Longitude', 0).eq("LapCount", lap)
+            f = Filter().neq('Latitude', 0).and_().neq('Longitude', 0).eq("CurrentLap", lap)
             dataset = self.query(sessions = [session], 
                                             channels = ["Latitude", "Longitude"], 
                                             data_filter = f)

--- a/autosportlabs/racecapture/views/analysis/sessionbrowser.py
+++ b/autosportlabs/racecapture/views/analysis/sessionbrowser.py
@@ -141,24 +141,16 @@ class SessionBrowser(AnchorLayout):
         try:
             self.clear_sessions()
             sessions = self.datastore.get_sessions()
-            f = Filter().gt('LapCount', 0)
+            f = Filter().gt('CurrentLap', 0)
             session = None
             for session in sessions:
                 session = self.append_session(session_id=session.session_id, name=session.name, notes=session.notes)
-                dataset = self.datastore.query(sessions=[session.session_id],
-                                        channels=['LapCount', 'LapTime'],
-                                        data_filter=f,
-                                        distinct_records=True)
-        
-                records = dataset.fetch_records()
-                lap_count = 0
-                for r in records:
-                    lap_id = int(r[1])
-                    laptime = r[2]
-                    self.append_lap(session, lap_id, laptime)
-                    lap_count += 1
-                if lap_count == 0:
-                    session.append_label('No Laps')
+                laps = self.datastore.get_laps(session.session_id)
+                if len(laps) == 0:
+                    session.append_label('No Laps') 
+                else:
+                    for lap in laps:
+                        self.append_lap(session, lap.lap, lap.lap_time)
 
             self.sessions = sessions
             self.ids.session_alert.text = '' if session else 'No Sessions'


### PR DESCRIPTION
We should be selecting laps based on CurrentLap channel and display the lap time as the max of the ElapsedTime for that CurrentLap, and not use LapCount / LapTime channels, as those reference the number of laps so far, and the last lap time.

This Resolves #863 
