### PR TITLE
Change race-capture.com references to Podium

### DIFF
--- a/autosportlabs/racecapture/tracks/trackmanager.py
+++ b/autosportlabs/racecapture/tracks/trackmanager.py
@@ -109,7 +109,7 @@ class TrackMap:
 class TrackManager:
     """Manages fetching tracks from RCL's API, figuring out if any tracks have been updated, saving and loading tracks
     """
-    RCP_VENUE_URL = 'https://race-capture.com/api/v1/venues'
+    RCP_VENUE_URL = 'https://podium.live/api/v1/venues'
     READ_RETRIES = 3
     RETRY_DELAY = 1.0
 

--- a/autosportlabs/telemetry/telemetryconnection.py
+++ b/autosportlabs/telemetry/telemetryconnection.py
@@ -29,7 +29,7 @@ class TelemetryManager(EventDispatcher):
     telemetry_enabled = BooleanProperty(False)
 
     def __init__(self, data_bus, device_id=None, host=None, port=None, **kwargs):
-        self.host = 'race-capture.com'
+        self.host = 'telemetry.podium.live'
         self.port = 8080
         self.connection = None
         self._connection_process = None


### PR DESCRIPTION
Pretty simple. This already works because podium.live is the RCL codebase.