### PR TITLE
do not ever ever start sample worker if on mobile platform

### DIFF
--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -249,8 +249,8 @@ class DataBusPump(object):
                 rc_api.sample()
                 sleep(SAMPLE_POLL_INTERVAL_TIMEOUT)
             except Exception as e:
-                sleep(SAMPLE_POLL_EXCEPTION_RECOVERY)
                 Logger.error('DataBusPump: Exception in sample_worker: ' + str(e))
+                sleep(SAMPLE_POLL_EXCEPTION_RECOVERY)
 
         Logger.info('DataBusPump: sample_worker exiting')
         safe_thread_exit()

--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -7,6 +7,7 @@ from autosportlabs.racecapture.data.sampledata import Sample, SampleMetaExceptio
 from autosportlabs.racecapture.databus.filter.bestlapfilter import BestLapFilter
 from autosportlabs.racecapture.databus.filter.laptimedeltafilter import LaptimeDeltaFilter
 from autosportlabs.util.threadutil import safe_thread_exit, ThreadSafeDict
+from utils import is_mobile_platform
 
 DEFAULT_DATABUS_UPDATE_INTERVAL = 0.02  # 50Hz UI update rate
 
@@ -178,25 +179,28 @@ class DataBusPump(object):
         super(DataBusPump, self).__init__(**kwargs)
 
     def start(self, data_bus, rc_api):
-        if self._sample_thread == None:
-            self._rc_api = rc_api
-            self._data_bus = data_bus
-
-            rc_api.addListener('s', self.on_sample)
-            rc_api.addListener('meta', self.on_meta)
-
-            self._running.set()
+        if self._running.is_set():
+            # since we're already running, simply
+            # request updated metadata
+            self.meta_is_stale()
+            return
+                    
+        self._rc_api = rc_api
+        self._data_bus = data_bus
+        rc_api.addListener('s', self.on_sample)
+        rc_api.addListener('meta', self.on_meta)
+        self._running.set()
+        if not is_mobile_platform():
+            #only start the worker on desktop mode
             t = Thread(target=self.sample_worker)
             t.start()
             self._sample_thread = t
-        else:
-            # we're already running, refresh channel meta data
-            self.meta_is_stale()
 
     def stop(self):
         self._running.clear()
         try:
-            self._sample_thread.join()
+            if self._sample_thread is not None:
+                self._sample_thread.join()
         except Exception as e:
             Logger.warning('DataBusPump: Failed to join sample_worker: {}'.format(e))
 
@@ -239,29 +243,14 @@ class DataBusPump(object):
 
     def sample_worker(self):
         rc_api = self._rc_api
-        sample_event = self._sample_event
-
         Logger.info('DataBusPump: sample_worker starting')
-
-        sample_event.clear()
-        if sample_event.wait(SAMPLE_POLL_TEST_TIMEOUT) == True:
-            Logger.info('DataBusPump: Async sampling detected')
-        else:
-            Logger.info('DataBusPump: Synchronous sampling mode enabled')
-            while self._running.is_set():
-                try:
-                    # the timeout here is designed to be longer than the streaming rate of
-                    # RaceCapture. If we don't get an asynchronous sample, then we will timeout
-                    # and request a sample anyway.
-                    rc_api.sample()
-                    sample_event.wait(SAMPLE_POLL_EVENT_TIMEOUT)
-                    sample_event.clear()
-                    sleep(SAMPLE_POLL_INTERVAL_TIMEOUT)
-                except Exception as e:
-                    sleep(SAMPLE_POLL_EXCEPTION_RECOVERY)
-                    Logger.error('DataBusPump: Exception in sample_worker: ' + str(e))
-                finally:
-                    sample_event.clear()
+        while self._running.is_set():
+            try:
+                rc_api.sample()
+                sleep(SAMPLE_POLL_INTERVAL_TIMEOUT)
+            except Exception as e:
+                sleep(SAMPLE_POLL_EXCEPTION_RECOVERY)
+                Logger.error('DataBusPump: Exception in sample_worker: ' + str(e))
 
         Logger.info('DataBusPump: sample_worker exiting')
         safe_thread_exit()


### PR DESCRIPTION
this acknowledges that on the mobile platform we should never, ever enable the polling sampler.  There could be a case (and it's been seen on slower hardware maybe) where the wait period times out and the app starts polling for samples over BT.  We should only poll on USB, and then later, we'll have the API to enable / disable streaming.  This is a step in that direction.

This may also help mitigate some of the timeouts seen when writing configurations if the sampleworker incorrectly starts up. still, there's likely more work needed in this area. 

Finally, this code is simpler. simpler = better. 