### PR TITLE
Adjust center dashboard gauge

### DIFF
--- a/autosportlabs/racecapture/views/dashboard/gaugeview.kv
+++ b/autosportlabs/racecapture/views/dashboard/gaugeview.kv
@@ -33,7 +33,7 @@
             anchor_x:'center'
             anchor_y:'center'
             BoxLayout:
-                size_hint_x: 0.5
+                size_hint_x: 0.47
                 orientation: 'vertical'
                 RoundGauge:
                     rcid: 'center'


### PR DESCRIPTION
slightly shrink center dashboard gauge to eliminate / reduce chances of overlap on certain aspect ratio displays