### PR TITLE
P/brentpicasso/pit stop timer config

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,6 @@
 ==1.5.3==
+* Make pit stop timer configurable
+* Make pit stop timer time correctly on slower tablets
 
 ==1.5.2==
 * Prevent app hang while transmitting telemetry if bluetooth disconnects

--- a/autosportlabs/racecapture/databus/databus.py
+++ b/autosportlabs/racecapture/databus/databus.py
@@ -146,11 +146,10 @@ class DataBus(object):
         :param listener
         :type object / callback function
         '''
-        Logger.info('DataBus: remove sample listener {}'.format(listener))
         try:
             self.sample_listeners.remove(listener)
         except Exception as e:
-            Logger.error('Could not remove sample listener {}: {}'.format(listener, e))
+            Logger.debug('Could not remove sample listener {}: {}'.format(listener, e))
         
     def remove_meta_listener(self, listener):
         '''
@@ -158,11 +157,10 @@ class DataBus(object):
         :param listener
         :type object / callback function
         '''
-        Logger.info('DataBus: remove meta listener {}'.format(listener))
         try:
             self.meta_listeners.remove(listener)
         except Exception as e:
-            Logger.error('Could not remove meta listener {}: {}'.format(listener, e))
+            Logger.debug('Could not remove meta listener {}: {}'.format(listener, e))
         
     def add_sample_listener(self, callback):
         self.sample_listeners.append(callback)

--- a/autosportlabs/racecapture/settings/prefs.py
+++ b/autosportlabs/racecapture/settings/prefs.py
@@ -213,7 +213,7 @@ class UserPrefs(EventDispatcher):
         '''
         try:
             return self.config.getboolean(section, option)
-        except NoOptionError:
+        except (NoOptionError, ValueError):
             return default
 
     def get_pref_float(self, section, option, default=None):
@@ -230,7 +230,7 @@ class UserPrefs(EventDispatcher):
         '''
         try:
             return self.config.getfloat(section, option)
-        except NoOptionError:
+        except (NoOptionError, ValueError):
             return default
 
     def get_pref_int(self, section, option, default=None):
@@ -247,7 +247,7 @@ class UserPrefs(EventDispatcher):
         '''
         try:
             return self.config.getint(section, option)
-        except NoOptionError:
+        except (NoOptionError, ValueError):
             return default
 
     def get_pref(self, section, option, default=None):
@@ -264,7 +264,7 @@ class UserPrefs(EventDispatcher):
         '''
         try:
             return self.config.get(section, option)
-        except NoOptionError:
+        except (NoOptionError, ValueError):
             return default
 
     def set_pref(self, section, option, value):

--- a/autosportlabs/racecapture/settings/prefs.py
+++ b/autosportlabs/racecapture/settings/prefs.py
@@ -10,6 +10,9 @@ from os import path
 from os.path import dirname, expanduser, sep
 
 class Range(EventDispatcher):
+    '''
+    Represents a object to manage ranges to facilitate warning / alert functions
+    '''
     DEFAULT_WARN_COLOR = [1.0, 0.84, 0.0, 1.0]
     DEFAULT_ALERT_COLOR = [1.0, 0.0, 0.0, 1.0]
     max = NumericProperty(None)
@@ -22,14 +25,28 @@ class Range(EventDispatcher):
         self.color = kwargs.get('color', self.color)
 
     def is_in_range(self, value):
+        '''
+        Query if value is in range
+        :param value value to compare
+        :type float
+        :return bool if value is in range
+        '''
         min = self.min
         max = self.max
         return (min is not None and max is not None) and self.min <= value <= self.max
 
     def to_json(self):
+        '''
+        Serialize to a json string
+        :return string 
+        '''
         return json.dumps(self.to_dict())
 
     def to_dict(self):
+        '''
+        Get dictionary representation of object
+        :return dict
+        '''
         return {'min': self.min,
                 'max': self.max,
                 'color': self.color
@@ -37,14 +54,29 @@ class Range(EventDispatcher):
 
     @staticmethod
     def from_json(range_json):
+        '''
+        Factory method to create an instance from JSON
+        :param range_json JSON string
+        :type range_json string
+        :return Range object
+        '''
         range_dict = json.loads(range_json)
         return Range.from_dict(range_dict)
 
     @staticmethod
     def from_dict(range_dict):
+        '''
+        Factory method to create an instance from a dict
+        :param range_dict dict representing Range object
+        :type range_dict dict
+        :return Range object
+        '''
         return Range(minimum=range_dict['min'], maximum=range_dict['max'], color=range_dict['color'])
 
 class UserPrefs(EventDispatcher):
+    '''
+    A class to manage user preferences for the RaceCapture app
+    '''
     _schedule_save = None
     _prefs_dict = {'range_alerts': {}, 'gauge_settings':{}}
     store = None
@@ -62,29 +94,64 @@ class UserPrefs(EventDispatcher):
         self._schedule_save = Clock.create_trigger(self.save, save_timeout)
 
     def set_range_alert(self, key, range_alert):
+        '''
+        Sets a range alert with the specified key
+        :param key the key for the range alert
+        :type string
+        :param range_alert the range alert
+        :type object
+        '''
         self._prefs_dict["range_alerts"][key] = range_alert
         self._schedule_save()
 
     def get_range_alert(self, key, default=None):
+        '''
+        Retrives a range alert for the specified key
+        :param key the key for the range alert
+        :type key string
+        :param default the default value, optional
+        :type default user specified
+        :return the range alert, or the default value 
+        '''
         return self._prefs_dict["range_alerts"].get(key, default)
 
     def set_gauge_config(self, gauge_id, channel):
+        '''
+        Stores a gauge configuration for the specified gauge_id
+        :param gauge_id the key for the gauge
+        :type gauge_id string
+        :param channel the configuration for the channel
+        :type channel object
+        '''
         self._prefs_dict["gauge_settings"][gauge_id] = channel
         self._schedule_save()
+
+    def get_gauge_config(self, gauge_id):
+        '''
+        Get the gauge configuration for the specified gauge_id
+        :param gauge_id the key for the gauge
+        :type string
+        :return the gauge configuration
+        '''
+        return self._prefs_dict["gauge_settings"].get(gauge_id, False)
 
     @property
     def datastore_location(self):
         return self.config.get('preferences', 'dstore_path')
 
-    def get_gauge_config(self, gauge_id):
-        return self._prefs_dict["gauge_settings"].get(gauge_id, False)
-
     def save(self, *largs):
+        '''
+        Saves the current configuration
+        '''
         with open(self.prefs_file, 'w+') as prefs_file:
             data = self.to_json()
             prefs_file.write(data)
 
     def set_config_defaults(self):
+        '''
+        Set defaults for preferences 
+        '''
+        # Base system preferences
         self.config.adddefaultsection('help')
         self.config.adddefaultsection('preferences')
         self.config.setdefault('preferences', 'distance_units', 'miles')
@@ -100,6 +167,13 @@ class UserPrefs(EventDispatcher):
         self.config.setdefault('preferences', 'send_telemetry', False)
         self.config.setdefault('preferences', 'last_dash_screen', 'gaugeView')
         self.config.setdefault('preferences', 'global_help', True)
+
+        # Dashboard preferences
+        self.config.adddefaultsection('dashboard_preferences')
+        self.config.setdefault('dashboard_preferences', 'pitstoptimer_enabled', 1)
+        self.config.setdefault('dashboard_preferences', 'pitstoptimer_trigger_speed', 5.0)
+        self.config.setdefault('dashboard_preferences', 'pitstoptimer_alert_speed', 25.0)
+        self.config.setdefault('dashboard_preferences', 'pitstoptimer_exit_speed', 55.0)
 
     def load(self):
         Logger.info('UserPrefs: Data Dir is: {}'.format(self.data_dir))
@@ -125,17 +199,91 @@ class UserPrefs(EventDispatcher):
         except Exception:
             pass
 
+    def get_pref_bool(self, section, option, default=None):
+        '''
+        Retrieve a preferences value as a bool. 
+        return default value if preference does not exist
+        :param section the configuration section for the preference
+        :type section string
+        :param option the option for the section
+        :type option string
+        :param default
+        :type default bool
+        :return bool preference value
+        '''
+        try:
+            return self.config.getboolean(section, option)
+        except NoOptionError:
+            return default
+
+    def get_pref_float(self, section, option, default=None):
+        '''
+        Retrieve a preferences value as a float. 
+        return default value if preference does not exist
+        :param section the configuration section for the preference
+        :type section string
+        :param option the option for the section
+        :type option string
+        :param default
+        :type default float
+        :return float preference value
+        '''
+        try:
+            return self.config.getfloat(section, option)
+        except NoOptionError:
+            return default
+
+    def get_pref_int(self, section, option, default=None):
+        '''
+        Retrieve a preferences value as an int. 
+        return default value if preference does not exist
+        :param section the configuration section for the preference
+        :type section string
+        :param option the option for the section
+        :type option string
+        :param default
+        :type default user specified
+        :return int preference value
+        '''
+        try:
+            return self.config.getint(section, option)
+        except NoOptionError:
+            return default
+
     def get_pref(self, section, option, default=None):
+        '''
+        Retrieve a preferences value as a string. 
+        return default value if preference does not exist
+        :param section the configuration section for the preference
+        :type section string
+        :param option the option for the section
+        :type option string
+        :param default
+        :type default user specified
+        :return string preference value
+        '''
         try:
             return self.config.get(section, option)
         except NoOptionError:
             return default
 
     def set_pref(self, section, option, value):
+        '''
+        Set a preference value
+        :param section the configuration section for the preference
+        :type string
+        :param option the option for the section
+        :type string
+        :param value the preference value to set
+        :type value user specified
+        '''
         self.config.set(section, option, value)
         self.config.write()
 
     def to_json(self):
+        '''
+        Serialize preferences to json
+        '''
         data = {'range_alerts': {}, 'gauge_settings':{}}
 
         for name, range_alert in self._prefs_dict["range_alerts"].iteritems():

--- a/autosportlabs/racecapture/settings/prefs.py
+++ b/autosportlabs/racecapture/settings/prefs.py
@@ -171,9 +171,9 @@ class UserPrefs(EventDispatcher):
         # Dashboard preferences
         self.config.adddefaultsection('dashboard_preferences')
         self.config.setdefault('dashboard_preferences', 'pitstoptimer_enabled', 1)
-        self.config.setdefault('dashboard_preferences', 'pitstoptimer_trigger_speed', 5.0)
-        self.config.setdefault('dashboard_preferences', 'pitstoptimer_alert_speed', 25.0)
-        self.config.setdefault('dashboard_preferences', 'pitstoptimer_exit_speed', 55.0)
+        self.config.setdefault('dashboard_preferences', 'pitstoptimer_trigger_speed', 5)
+        self.config.setdefault('dashboard_preferences', 'pitstoptimer_alert_speed', 25)
+        self.config.setdefault('dashboard_preferences', 'pitstoptimer_exit_speed', 55)
 
     def load(self):
         Logger.info('UserPrefs: Data Dir is: {}'.format(self.data_dir))

--- a/autosportlabs/racecapture/settings/systemsettings.py
+++ b/autosportlabs/racecapture/settings/systemsettings.py
@@ -5,6 +5,14 @@ from kivy.utils import platform
 from os.path import dirname, expanduser, sep
 from os import path
 
+class SettingsListener(object):
+
+    def settings_updated(self, settings):
+        pass
+
+    def user_preferences_updated(self, user_prefs):
+        pass
+
 class SystemSettings(object):
     data_dir = None
     base_dir = None
@@ -12,8 +20,8 @@ class SystemSettings(object):
         self.data_dir = data_dir
         self.base_dir = base_dir
         self.systemChannels = SystemChannels(base_dir=base_dir)
-        self.runtimeChannels = RuntimeChannels(system_channels=self.systemChannels)        
-        self.userPrefs = UserPrefs(data_dir=self.get_default_data_dir(), 
+        self.runtimeChannels = RuntimeChannels(system_channels=self.systemChannels)
+        self.userPrefs = UserPrefs(data_dir=self.get_default_data_dir(),
                                    user_files_dir=self.get_default_user_files_dir())
         self.appConfig = AppConfig()
 
@@ -25,7 +33,7 @@ class SystemSettings(object):
             return activity.getExternalFilesDir(None).getPath()
         else:
             return self.data_dir
-        
+
     def get_default_user_files_dir(self):
         if platform() == 'android':
             from jnius import autoclass
@@ -40,4 +48,4 @@ class SystemSettings(object):
         else:
             return path.join(expanduser('~'), 'Documents')
 
-        
+

--- a/autosportlabs/racecapture/settings/systemsettings.py
+++ b/autosportlabs/racecapture/settings/systemsettings.py
@@ -6,11 +6,24 @@ from os.path import dirname, expanduser, sep
 from os import path
 
 class SettingsListener(object):
+    '''
+    Base class for listining to changes in settings / preferences
+    '''
 
     def settings_updated(self, settings):
+        '''
+        Notify if settings have been updated
+        :param settings the settings object
+        :type settings SystemSettings
+        '''
         pass
 
     def user_preferences_updated(self, user_prefs):
+        '''
+        Notify if user preferences have changed
+        :param user_prefs user preferences
+        :type UserPrefs
+        '''
         pass
 
 class SystemSettings(object):

--- a/autosportlabs/racecapture/views/dashboard/dashboardview.kv
+++ b/autosportlabs/racecapture/views/dashboard/dashboardview.kv
@@ -11,7 +11,6 @@
     			IconButton:
     				color: [1.0, 1.0, 1.0, 1.0]
     				font_size: self.height
-    				rcid: 'teleRxStatus'
     				text: ' \357\203\231'
     				size_hint_x: 0.2
     				on_release: root.on_nav_left()
@@ -24,7 +23,6 @@
     			IconButton:
     				color: [1.0, 1.0, 1.0, 1.0]
     				font_size: self.height
-    				rcid: 'teleRxStatus'
     				text: '\357\203\232 '
     				size_hint_x: 0.2
     				on_release: root.on_nav_right()
@@ -32,10 +30,11 @@
             anchor_x: 'left'
             anchor_y: 'top'
             IconButton:
+                id: preferences_button
                 size_hint_y: 0.1
                 size_hint_x: 0.1
                 text: u'\uf013'
                 halign: 'left'
-                color: [1.0, 1.0, 1.0, 0.5]
+                color: [1.0, 1.0, 1.0, 0.2]
                 on_press: root.on_preferences()
 

--- a/autosportlabs/racecapture/views/dashboard/dashboardview.kv
+++ b/autosportlabs/racecapture/views/dashboard/dashboardview.kv
@@ -1,30 +1,41 @@
 <DashboardView>:
-	BoxLayout:
-		orientation: 'vertical'
-		ScreenManager:
-			rcid: 'screens'
-			size_hint_y: 0.90
-		BoxLayout:
-			size_hint_y: 0.10
-			orientation: 'horizontal'
-			IconButton:
-				color: [1.0, 1.0, 1.0, 1.0]
-				font_size: self.height
-				rcid: 'teleRxStatus'
-				text: ' \357\203\231'
-				size_hint_x: 0.2
-				on_release: root.on_nav_left()   				
-			DigitalGauge:
-				rcid: 'left_bottom'
-			DigitalGauge:
-				rcid: 'center_bottom'
-			DigitalGauge:
-				rcid: 'right_bottom'
-			IconButton:
-				color: [1.0, 1.0, 1.0, 1.0]
-				font_size: self.height
-				rcid: 'teleRxStatus'
-				text: '\357\203\232 '
-				size_hint_x: 0.2
-				on_release: root.on_nav_right()
+    AnchorLayout:
+    	BoxLayout:
+    		orientation: 'vertical'
+    		ScreenManager:
+    			rcid: 'screens'
+    			size_hint_y: 0.90
+    		BoxLayout:
+    			size_hint_y: 0.10
+    			orientation: 'horizontal'
+    			IconButton:
+    				color: [1.0, 1.0, 1.0, 1.0]
+    				font_size: self.height
+    				rcid: 'teleRxStatus'
+    				text: ' \357\203\231'
+    				size_hint_x: 0.2
+    				on_release: root.on_nav_left()
+    			DigitalGauge:
+    				rcid: 'left_bottom'
+    			DigitalGauge:
+    				rcid: 'center_bottom'
+    			DigitalGauge:
+    				rcid: 'right_bottom'
+    			IconButton:
+    				color: [1.0, 1.0, 1.0, 1.0]
+    				font_size: self.height
+    				rcid: 'teleRxStatus'
+    				text: '\357\203\232 '
+    				size_hint_x: 0.2
+    				on_release: root.on_nav_right()
+        AnchorLayout:
+            anchor_x: 'left'
+            anchor_y: 'top'
+            IconButton:
+                size_hint_y: 0.1
+                size_hint_x: 0.1
+                text: u'\uf013'
+                halign: 'left'
+                color: [1.0, 1.0, 1.0, 0.5]
+                on_press: root.on_preferences()
 

--- a/autosportlabs/racecapture/views/dashboard/dashboardview.py
+++ b/autosportlabs/racecapture/views/dashboard/dashboardview.py
@@ -10,6 +10,7 @@ from autosportlabs.racecapture.views.dashboard.widgets.stopwatch import PitstopT
 from autosportlabs.racecapture.settings.systemsettings import SettingsListener
 from kivy.uix.settings import SettingsWithNoMenu
 from kivy.app import Builder
+from kivy.core.window import Window
 from kivy.uix.screenmanager import *
 from autosportlabs.racecapture.views.dashboard.widgets.tachometer import Tachometer
 from utils import kvFind, kvFindClass
@@ -44,6 +45,7 @@ class DashboardView(Screen):
         self.init_view()
         self._dismiss_popup_trigger = Clock.create_trigger(self._dismiss_popup, POPUP_DISMISS_TIMEOUT_LONG)
         self._popup = None
+        
 
     def on_tracks_updated(self, trackmanager):
         pass
@@ -97,7 +99,25 @@ class DashboardView(Screen):
         self._notify_preference_listeners()
         Clock.schedule_once(lambda dt: self._show_last_view())
 
-
+    def on_enter(self):
+        Window.bind(mouse_pos=self.on_mouse_pos)
+        
+    def on_leave(self):
+        Window.unbind(mouse_pos=self.on_mouse_pos)
+        
+    def _got_activity(self):
+        self.ids.preferences_button.brighten()
+        
+    def on_touch_down(self, touch):
+        self._got_activity()
+        return super(DashboardView, self).on_touch_down(touch)
+    
+    def on_mouse_pos(self, x, pos):
+        if self.collide_point(pos[0], pos[1]):
+            self._got_activity()
+            self.ids.preferences_button.brighten()
+        return False
+    
     def on_preferences(self, *args):
         settings_view = SettingsWithNoMenu()
         base_dir = self._settings.base_dir

--- a/autosportlabs/racecapture/views/dashboard/dashboardview.py
+++ b/autosportlabs/racecapture/views/dashboard/dashboardview.py
@@ -7,6 +7,8 @@ from autosportlabs.racecapture.views.dashboard.comboview import ComboView
 from autosportlabs.racecapture.views.dashboard.gaugeview import GaugeView
 from autosportlabs.racecapture.views.dashboard.widgets.digitalgauge import DigitalGauge
 from autosportlabs.racecapture.views.dashboard.widgets.stopwatch import PitstopTimerView
+from autosportlabs.racecapture.settings.systemsettings import SettingsListener
+from kivy.uix.settings import SettingsWithNoMenu
 from kivy.app import Builder
 from kivy.uix.screenmanager import *
 from autosportlabs.racecapture.views.dashboard.widgets.tachometer import Tachometer
@@ -14,61 +16,66 @@ from utils import kvFind, kvFindClass
 from autosportlabs.racecapture.views.dashboard.widgets.gauge import Gauge
 from kivy.logger import Logger
 from kivy.clock import Clock
+from kivy.uix.modalview import ModalView
+import os
 
 DASHBOARD_VIEW_KV = 'autosportlabs/racecapture/views/dashboard/dashboardview.kv'
+POPUP_DISMISS_TIMEOUT_LONG = 60.0
+
 
 class DashboardView(Screen):
-    
-    _settings = None
-    _databus = None
-    _screen_mgr = None
-    _gaugeView = None
-    _tachView = None
-    _rawchannelView = None
-    _laptimeView = None
-    _comboView = None
+    _POPUP_SIZE_HINT = (0.75, 0.8)
     Builder.load_file(DASHBOARD_VIEW_KV)
-    
+
     def __init__(self, **kwargs):
+        _settings = None
+        _databus = None
+        _screen_mgr = None
+        _gaugeView = None
+        _tachView = None
+        _rawchannelView = None
+        _laptimeView = None
+        _comboView = None
         super(DashboardView, self).__init__(**kwargs)
         self.register_event_type('on_tracks_updated')
         self._databus = kwargs.get('dataBus')
         self._settings = kwargs.get('settings')
         self._alert_widgets = {}
         self.init_view()
+        self._dismiss_popup_trigger = Clock.create_trigger(self._dismiss_popup, POPUP_DISMISS_TIMEOUT_LONG)
+        self._popup = None
 
-            
     def on_tracks_updated(self, trackmanager):
         pass
-        
+
     def initGlobalGauges(self):
         databus = self._databus
         settings = self._settings
- 
+
         activeGauges = list(kvFindClass(self, Gauge))
-        
+
         for gauge in activeGauges:
             gauge.settings = settings
             gauge.data_bus = databus
-         
+
     def init_view(self):
         screenMgr = kvFind(self, 'rcid', 'screens')
-        
+
         databus = self._databus
         settings = self._settings
-        
+
         self.initGlobalGauges()
-        
+
         gaugeView = GaugeView(name='gaugeView', databus=databus, settings=settings)
         tachView = TachometerView(name='tachView', databus=databus, settings=settings)
         laptimeView = LaptimeView(name='laptimeView', databus=databus, settings=settings)
-        #comboView = ComboView(name='comboView', databus=databus, settings=settings)
+        # comboView = ComboView(name='comboView', databus=databus, settings=settings)
         rawChannelView = RawChannelView(name='rawchannelView', databus=databus, settings=settings)
-        
+
         screenMgr.add_widget(gaugeView)
         screenMgr.add_widget(tachView)
-        screenMgr.add_widget(laptimeView) 
-        #screenMgr.add_widget(comboView)
+        screenMgr.add_widget(laptimeView)
+        # screenMgr.add_widget(comboView)
         screenMgr.add_widget(rawChannelView)
 
         gauges = list(kvFindClass(self, DigitalGauge))
@@ -81,22 +88,47 @@ class DashboardView(Screen):
         self._tachView = tachView
         self._rawchannelView = rawChannelView
         self._laptimeView = laptimeView
-        #self._comboView = comboView
+        # self._comboView = comboView
         self._screen_mgr = screenMgr
-        
+
         self._alert_widgets['pit_stop'] = PitstopTimerView(databus, 'Pit Stop')
-        
+
         databus.start_update()
+        self._notify_preference_listeners()
         Clock.schedule_once(lambda dt: self._show_last_view())
-        
-        
+
+
+    def on_preferences(self, *args):
+        settings_view = SettingsWithNoMenu()
+        base_dir = self._settings.base_dir
+        settings_view.add_json_panel('Dashboard Preferences', self._settings.userPrefs.config, os.path.join(base_dir, 'resource', 'settings', 'dashboard_settings.json'))
+
+        popup = ModalView(size_hint=self._POPUP_SIZE_HINT)
+        popup.add_widget(settings_view)
+        popup.bind(on_dismiss=self._popup_dismissed)
+        popup.open()
+        self._popup = popup
+        # self._dismiss_popup_trigger()
+
+    def _popup_dismissed(self, *args):
+        self._notify_preference_listeners()
+
+    def _dismiss_popup(self, *args):
+        if self._popup:
+            self._popup.dismiss()
+            self._popup = None
+
+    def _notify_preference_listeners(self):
+        listeners = list(kvFindClass(self, SettingsListener)) + self._alert_widgets.values()
+        for listener in listeners:
+            listener.user_preferences_updated(self._settings.userPrefs)
 
     def on_nav_left(self):
-        self._screen_mgr.transition=SlideTransition(direction='right')
+        self._screen_mgr.transition = SlideTransition(direction='right')
         self._show_screen(self._screen_mgr.previous())
 
     def on_nav_right(self):
-        self._screen_mgr.transition=SlideTransition(direction='left')
+        self._screen_mgr.transition = SlideTransition(direction='left')
         self._show_screen(self._screen_mgr.next())
 
     def _show_screen(self, screen):

--- a/autosportlabs/racecapture/views/dashboard/widgets/stopwatch.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/stopwatch.py
@@ -11,6 +11,7 @@ from kivy.clock import Clock
 from autosportlabs.racecapture.views.util.viewutils import format_laptime
 from iconbutton import RoundedRect
 from autosportlabs.racecapture.theme.color import ColorScheme
+from time import time
 
 STOPWATCH_LAYOUT='''
 <PitstopTimerView>:
@@ -120,8 +121,8 @@ class PitstopTimerView(BoxLayout):
         self.title = title
         self.databus = databus
         self._popup = None
-        self._current_time = 0.0
         self._flash_count = 0
+        self._start_time = 0.0
         self._currently_racing = False
         databus.addChannelListener(STOPWATCH_SPEED_CHANNEL, self.set_speed)
         databus.addChannelListener(STOPWATCH_CURRENT_LAP, self.set_current_lap)
@@ -175,7 +176,7 @@ class PitstopTimerView(BoxLayout):
         '''
         Increment the current stopwatch time
         '''
-        self._current_time += self._STOPWATCH_TICK
+        self._current_time = time() - self._start_time
         self.current_time = self._format_stopwatch_time()
         self.exit_speed = '{}'.format(int(self.current_speed))
         if self.current_speed > self.stop_threshold_speed:
@@ -205,7 +206,8 @@ class PitstopTimerView(BoxLayout):
             self._popup.add_widget(self)
         self._set_exit_speed_frame_visible(False)
         self._popup.open()
-        self._current_time = 0
+        self._current_time = 0.0
+        self._start_time = time()
         self._flash_count = 0
         self._currently_racing = False
         Clock.schedule_interval(self._tick_stopwatch, self._STOPWATCH_TICK)

--- a/autosportlabs/racecapture/views/dashboard/widgets/stopwatch.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/stopwatch.py
@@ -121,9 +121,9 @@ class PitstopTimerView(BoxLayout, SettingsListener):
         self._flash_count = 0
         self._start_time = 0.0
         self._currently_racing = False
-        self._pitstop_trigger_speed = 0.0
-        self._pitstop_exit_speed = 0.0
-        self._pitstop_alert_speed = 0.0
+        self._pitstop_trigger_speed = 0
+        self._pitstop_exit_speed = 0
+        self._pitstop_alert_speed = 0
         databus.addChannelListener(STOPWATCH_SPEED_CHANNEL, self.set_speed)
         databus.addChannelListener(STOPWATCH_CURRENT_LAP, self.set_current_lap)
 
@@ -202,9 +202,9 @@ class PitstopTimerView(BoxLayout, SettingsListener):
         Update runtime values from user preferences
         '''
         self._pitstop_timer_enabled = user_preferences.get_pref_bool('dashboard_preferences', 'pitstoptimer_enabled')
-        self._pitstop_trigger_speed = user_preferences.get_pref_float('dashboard_preferences', 'pitstoptimer_trigger_speed')
-        self._pitstop_exit_speed = user_preferences.get_pref_float('dashboard_preferences', 'pitstoptimer_exit_speed')
-        self._pitstop_alert_speed = user_preferences.get_pref_float('dashboard_preferences', 'pitstoptimer_alert_speed')
+        self._pitstop_trigger_speed = user_preferences.get_pref_int('dashboard_preferences', 'pitstoptimer_trigger_speed')
+        self._pitstop_exit_speed = user_preferences.get_pref_int('dashboard_preferences', 'pitstoptimer_exit_speed')
+        self._pitstop_alert_speed = user_preferences.get_pref_int('dashboard_preferences', 'pitstoptimer_alert_speed')
 
     def _start_stopwatch(self):
         '''

--- a/autosportlabs/racecapture/views/dashboard/widgets/stopwatch.py
+++ b/autosportlabs/racecapture/views/dashboard/widgets/stopwatch.py
@@ -11,9 +11,10 @@ from kivy.clock import Clock
 from autosportlabs.racecapture.views.util.viewutils import format_laptime
 from iconbutton import RoundedRect
 from autosportlabs.racecapture.theme.color import ColorScheme
+from autosportlabs.racecapture.settings.systemsettings import SettingsListener
 from time import time
 
-STOPWATCH_LAYOUT='''
+STOPWATCH_LAYOUT = '''
 <PitstopTimerView>:
     exit_speed_frame: exit_speed_frame.__self__
     orientation: 'vertical'
@@ -88,9 +89,9 @@ STOPWATCH_LAYOUT='''
 STOPWATCH_SPEED_CHANNEL = 'Speed'
 STOPWATCH_CURRENT_LAP = 'CurrentLap'
 
-STOPWATCH_NULL_TIME=''
+STOPWATCH_NULL_TIME = ''
 
-class PitstopTimerView(BoxLayout):
+class PitstopTimerView(BoxLayout, SettingsListener):
     '''
     Provides a pit stop timer that automatically activates when certain speed
     thresholds are met. 
@@ -102,20 +103,16 @@ class PitstopTimerView(BoxLayout):
     _TIMER_WIDGET_SIZE_HINT = 0.4
     _SPEED_ALERT_THRESHOLD = 0.85
     _POPUP_SIZE_HINT = (0.75, 0.8)
-    #Settings
-    stop_threshold_speed = NumericProperty(2.0)
-    resume_threshold_speed = NumericProperty(55.0)
-    exit_speed_alert_threshold = NumericProperty(35.0)
-    
+
     exit_speed_color = ListProperty(ColorScheme.get_dark_background_translucent())
     title = StringProperty('')
     current_time = StringProperty(STOPWATCH_NULL_TIME)
     exit_speed = StringProperty('')
     current_speed = NumericProperty(None)
     current_lap = NumericProperty(None)
-    
+
     Builder.load_string(STOPWATCH_LAYOUT)
-    
+
     def __init__(self, databus, title='Pit Stop', **kwargs):
         super(PitstopTimerView, self).__init__(**kwargs)
         self.title = title
@@ -124,9 +121,12 @@ class PitstopTimerView(BoxLayout):
         self._flash_count = 0
         self._start_time = 0.0
         self._currently_racing = False
+        self._pitstop_trigger_speed = 0.0
+        self._pitstop_exit_speed = 0.0
+        self._pitstop_alert_speed = 0.0
         databus.addChannelListener(STOPWATCH_SPEED_CHANNEL, self.set_speed)
         databus.addChannelListener(STOPWATCH_CURRENT_LAP, self.set_current_lap)
-    
+
     def _set_exit_speed_frame_visible(self, visible):
         '''
         Shows or hides the frame containing the exit speed indicator
@@ -147,7 +147,7 @@ class PitstopTimerView(BoxLayout):
         Format current laptime for display
         '''
         return format_laptime(self._current_time / 60.0)
-        
+
     def _toggle_exit_speed_alert(self, alert_color):
         '''
         Toggles the background color for the exit speed frame
@@ -156,22 +156,22 @@ class PitstopTimerView(BoxLayout):
             self.exit_speed_color = ColorScheme.get_dark_background_translucent()
         else:
             self.exit_speed_color = alert_color
-        
+
     def _update_speed_color(self):
         '''
         Selects the appropriate color for the exit speed indicator based on 
         configured speed threshold
         '''
-        if self.current_speed > self.exit_speed_alert_threshold:
+        if self.current_speed > self._pitstop_alert_speed:
             self.ids.speed_rect.rect_color = ColorScheme.get_error()
             self._toggle_exit_speed_alert(ColorScheme.get_error())
-        elif self.current_speed > self.exit_speed_alert_threshold * self._SPEED_ALERT_THRESHOLD:
+        elif self.current_speed > self._pitstop_alert_speed * self._SPEED_ALERT_THRESHOLD:
             self.ids.speed_rect.rect_color = ColorScheme.get_alert()
             self.exit_speed_color = ColorScheme.get_dark_background_translucent()
         else:
             self.ids.speed_rect.rect_color = ColorScheme.get_happy()
             self.exit_speed_color = ColorScheme.get_dark_background_translucent()
-        
+
     def _tick_stopwatch(self, *args):
         '''
         Increment the current stopwatch time
@@ -179,7 +179,7 @@ class PitstopTimerView(BoxLayout):
         self._current_time = time() - self._start_time
         self.current_time = self._format_stopwatch_time()
         self.exit_speed = '{}'.format(int(self.current_speed))
-        if self.current_speed > self.stop_threshold_speed:
+        if self.current_speed > self._pitstop_trigger_speed:
             self._set_exit_speed_frame_visible(True)
         self._update_speed_color()
 
@@ -188,19 +188,29 @@ class PitstopTimerView(BoxLayout):
         Stops the stopwatch timer
         '''
         Clock.unschedule(self._tick_stopwatch)
-        self.current_time =  STOPWATCH_NULL_TIME
+        self.current_time = STOPWATCH_NULL_TIME
 
     def _in_race_mode(self):
         '''
         Return True if we think we're in 'racing mode'
         '''
-        return self.current_speed > self.resume_threshold_speed and\
+        return self.current_speed > self._pitstop_exit_speed and\
             self.current_lap > 0
-            
+
+    def user_preferences_updated(self, user_preferences):
+        '''
+        Update runtime values from user preferences
+        '''
+        self._pitstop_timer_enabled = user_preferences.get_pref_bool('dashboard_preferences', 'pitstoptimer_enabled')
+        self._pitstop_trigger_speed = user_preferences.get_pref_float('dashboard_preferences', 'pitstoptimer_trigger_speed')
+        self._pitstop_exit_speed = user_preferences.get_pref_float('dashboard_preferences', 'pitstoptimer_exit_speed')
+        self._pitstop_alert_speed = user_preferences.get_pref_float('dashboard_preferences', 'pitstoptimer_alert_speed')
+
     def _start_stopwatch(self):
         '''
         Starts the stopwatch timer
         '''
+
         if not self._popup:
             self._popup = ModalView(size_hint=self._POPUP_SIZE_HINT, auto_dismiss=False)
             self._popup.add_widget(self)
@@ -211,14 +221,14 @@ class PitstopTimerView(BoxLayout):
         self._flash_count = 0
         self._currently_racing = False
         Clock.schedule_interval(self._tick_stopwatch, self._STOPWATCH_TICK)
-    
+
     def _is_popup_open(self):
         '''
         Indicates if current popup is open
         :return True if popup is currently open
         '''
         return self._popup and self._popup._window is not None
-        
+
     def _flash_pit_stop_time(self, *args):
         '''
         Flashes the final pit stop time when complete
@@ -229,7 +239,7 @@ class PitstopTimerView(BoxLayout):
             Clock.schedule_once(self._flash_pit_stop_time, self._FLASH_INTERVAL)
         else:
             self._popup.dismiss()
-        
+
     def _finish_stopwatch(self):
         '''
         Finish the current stopwatch
@@ -237,42 +247,45 @@ class PitstopTimerView(BoxLayout):
         self._flash_count = 0
         self.ids.speed_rect.rect_color = ColorScheme.get_dark_background_translucent()
         self.exit_speed_color = ColorScheme.get_dark_background_translucent()
-        self._set_exit_speed_frame_visible(False)        
+        self._set_exit_speed_frame_visible(False)
         Clock.schedule_once(self._flash_pit_stop_time)
         self._stop_stopwatch()
-        
+
     def check_popup(self):
         '''
         Check if we should pop-up the timer
         '''
+        if not self._pitstop_timer_enabled:
+            return
+
         if self._in_race_mode():
             self._currently_racing = True
-        if self.current_speed < self.stop_threshold_speed and\
+        if self.current_speed < self._pitstop_trigger_speed and\
                 self._currently_racing and\
                 not self._is_popup_open():
             self._start_stopwatch()
-        
-        if self.current_speed > self.resume_threshold_speed and\
+
+        if self.current_speed > self._pitstop_exit_speed and\
                 self._is_popup_open() and\
                 self._flash_count == 0:
             self._finish_stopwatch()
-            
+
     def on_current_speed(self, instance, value):
         self.check_popup()
-    
+
     def on_current_lap(self, instance, value):
         self.check_popup()
 
     def set_speed(self, value):
         self.current_speed = value
-    
+
     def set_current_lap(self, value):
         self.current_lap = value
 
     def dismiss(self):
         self._popup.dismiss()
         self._stop_stopwatch()
-        
+
     def change_font_size(self):
         '''
         Auto resizes the timer widget if it spills over the edge of the bounding box

--- a/autosportlabs/telemetry/telemetryconnection.py
+++ b/autosportlabs/telemetry/telemetryconnection.py
@@ -27,6 +27,7 @@ class TelemetryManager(EventDispatcher):
     device_id = StringProperty(None)
     cell_enabled = BooleanProperty(False)
     telemetry_enabled = BooleanProperty(False)
+    data_connected = BooleanProperty(False)
 
     def __init__(self, data_bus, device_id=None, host=None, port=None, **kwargs):
         self.host = 'telemetry.podium.live'
@@ -76,9 +77,8 @@ class TelemetryManager(EventDispatcher):
     # Event handler for when self.channels changes, don't restart connection b/c
     # the TelemetryConnection object will handle new channels
     def on_channels(self, instance, value):
-        Logger.debug("TelemetryManager: Got channels")
-
-        if self.telemetry_enabled:
+        if self.telemetry_enabled and value is not None:
+            Logger.info("TelemetryManager: Got channels")
             self.start()
 
     # Event handler for when self.device_id changes, need to restart connection
@@ -98,7 +98,7 @@ class TelemetryManager(EventDispatcher):
             self.start()
 
     def on_cell_enabled(self, instance, value):
-        Logger.debug("TelemetryManager: on_cell_enabled: " + str(value))
+        Logger.info("TelemetryManager: on_cell_enabled: " + str(value))
         if value:
             self._user_stopped()
         else:
@@ -106,10 +106,18 @@ class TelemetryManager(EventDispatcher):
             self.start()
 
     def on_telemetry_enabled(self, instance, value):
-        Logger.debug("TelemetryManager: on_telemetry_enabled: " + str(value))
+        Logger.info("TelemetryManager: on_telemetry_enabled: " + str(value))
         if value:
             self.start()
         else:
+            self._user_stopped()
+
+    def on_data_connected(self, instance, value):
+        Logger.info('TelemetryManager: on_data_connected: {}'.format(value))
+        if value:
+            self.start()
+        else:
+            self.channels = None
             self._user_stopped()
 
     # Event handler for when config is pulled from RCP
@@ -122,12 +130,24 @@ class TelemetryManager(EventDispatcher):
         self.cell_enabled = config.connectivityConfig.cellConfig.cellEnabled
         self.device_id = config.connectivityConfig.telemetryConfig.deviceId
 
+    @property
+    def _should_connect(self):
+        '''
+        checks if the conditions are correct for initiating a telemetry connection
+        :return True if a connection should be made
+        '''
+        return self.data_connected and\
+            self.telemetry_enabled and\
+            not self.cell_enabled and\
+            self.device_id != "" and\
+            self.channels is not None
+
     # Starts connection, checks to see if requirements are met
     def start(self):
         Logger.info("TelemetryManager: start() telemetry_enabled: " + str(self.telemetry_enabled) + " cell_enabled: " + str(self.cell_enabled))
         self._auth_failed = False
 
-        if self.telemetry_enabled and not self.cell_enabled and self.device_id != "" and self.channels is not None:
+        if self._should_connect:
             if self._connection_process and not self._connection_process.is_alive():
                 Logger.info("TelemetryManager: connection process is dead")
                 self._connect()
@@ -165,7 +185,6 @@ class TelemetryManager(EventDispatcher):
 
     def _user_stopped(self):
         self.dispatch('on_disconnected', '')
-        self.channels = None
         self.stop()
 
     # Status function that receives events from TelemetryConnection thread
@@ -187,7 +206,7 @@ class TelemetryManager(EventDispatcher):
             if not self._auth_failed:
                 self.dispatch('on_disconnected', msg)
 
-            if self.telemetry_enabled and not self.cell_enabled and not self._auth_failed:
+            if self._should_connect and not self._auth_failed:
                 wait = self.RETRY_WAIT_START if self._retry_count == 0 else \
                     min(self.RETRY_WAIT_MAX_TIME, (math.pow(self.RETRY_MULTIPLIER, self._retry_count) *
                                                    self.RETRY_WAIT_START))

--- a/iconbutton.py
+++ b/iconbutton.py
@@ -11,12 +11,60 @@ from kivy.properties import NumericProperty, ListProperty, StringProperty, Objec
 from fieldlabel import FieldLabel
 from math import sin, cos, pi
 from autosportlabs.racecapture.theme.color import ColorScheme 
+from kivy.clock import Clock
 
 Builder.load_file('iconbutton.kv')
 
 class IconButton(Button):
+    FADED_ALPHA = 0.1
+    BRIGHT_ALPHA = 1.0
+    FADE_STEP = 0.05
+    FADE_INTERVAL = 0.025
+    FADE_DELAY = 5.0
+    
     def __init__(self, **kwargs):
         super(IconButton, self).__init__(**kwargs)
+        self._current_alpha = None
+        self.brighten_mode = True
+        self._schedule_fade = Clock.create_trigger(self._fade_back, self.FADE_DELAY)
+        self._schedule_step = Clock.create_trigger(self._fade_step)
+    
+    def _fade_step(self, *args):
+        if self.brighten_mode == True:
+            if self._current_alpha < self.BRIGHT_ALPHA:
+                self._current_alpha += self.FADE_STEP
+                self._schedule_step()
+            
+        if self.brighten_mode == False:
+            if self._current_alpha > self.FADED_ALPHA:
+                self._current_alpha -= self.FADE_STEP
+                self._schedule_step()
+
+        color = self.color
+        self.color = [color[0], color[1], color[3], self._current_alpha]
+             
+    def _fade_back(self, *args):
+        self.fade()
+    
+    def _start_transition(self):
+        if self._current_alpha is None:
+            self._current_alpha = self.color[3]
+        self._schedule_step()
+        
+    def fade(self):
+        '''
+        Fade this button away to a shadow with low alpha value
+        '''
+        self.brighten_mode = False
+        self._start_transition()
+
+    def brighten(self):
+        '''
+        Brighten this button
+        '''        
+        self.brighten_mode = True
+        self._start_transition()
+        self._schedule_fade()
 
 class RoundedRect(BoxLayout):
     rect_color = ObjectProperty((0.5, 0.5, 0.5, 0.8))

--- a/main.py
+++ b/main.py
@@ -403,7 +403,7 @@ class RaceCaptureApp(App):
             self._status_pump.start(self._rc_api)
 
             if self.settings.userPrefs.get_pref('preferences', 'send_telemetry') == "1" and self._telemetry_connection:
-                self._telemetry_connection.telemetry_enabled = True
+                self._telemetry_connection.data_connected = True
 
             if self.rc_config.loaded == False:
                 Clock.schedule_once(lambda dt: self.on_read_config(self))
@@ -429,8 +429,8 @@ class RaceCaptureApp(App):
         self.showActivity('Searching {}'.format(info))
 
     def _on_rcp_disconnect(self):
-        if self._telemetry_connection.telemetry_enabled:
-            self._telemetry_connection.telemetry_enabled = False
+        if self._telemetry_connection.data_connected:
+            self._telemetry_connection.data_connected = False
 
     def open_settings(self, *largs):
         self.switchMainView('preferences')

--- a/resource/settings/dashboard_settings.json
+++ b/resource/settings/dashboard_settings.json
@@ -1,0 +1,35 @@
+[
+    {
+        "type": "title",
+        "title": "Pit Stop Timer"
+    },
+    {
+        "type": "bool",
+        "title": "Enable Pit Stop Timer",
+        "desc": "Enable a pit stop timer that activates upon a speed threshold. Must have lapping mode enabled",
+        "section": "dashboard_preferences",
+        "key": "pitstoptimer_enabled"
+    },
+    {
+    	"type": "numeric",
+    	"title": "Pit stop timer activation threshold",
+    	"desc": "Activates the timer when the speed drops under this threshold",
+    	"section": "dashboard_preferences",
+    	"key": "pitstoptimer_trigger_speed"
+    },
+    {
+        "type": "numeric",
+        "title": "Pit lane speed limit",
+        "desc": "Pit stop timer will alert driver if speed exceeds threshold.",
+        "section": "dashboard_preferences",
+        "key": "pitstoptimer_alert_speed"
+    },
+    {
+        "type": "numeric",
+        "title": "Pit stop timer exit speed",
+        "desc": "Pit stop timer will stop above this threshold, indicating back on race track",
+        "section": "dashboard_preferences",
+        "key": "pitstoptimer_exit_speed"
+    }
+    
+]


### PR DESCRIPTION
* Make pit stop timer configurable
* Introduce a preferences screen for the dashboard mode, include pit sop timer functions as a first set of preferences
* Correct timer incrementing issue (base it on actual time elapsed, not count on actual ticks happening on time)
* IconButton can now fade in and out as needed
* other refactorings

Resolves
 #958 
#948 