### PR TITLE
Make dash nav arrows bigger for easier use. Fixes #965

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@
 * Fix raw channels view font size being too big when few channels are configured (#98)
 * Wrap text in status screen instead of clip (#905)
 * Add network status to status page
+* Make dashboard nav arrows bigger
 
 ==1.5.2==
 * Prevent app hang while transmitting telemetry if bluetooth disconnects

--- a/autosportlabs/racecapture/views/dashboard/dashboardview.kv
+++ b/autosportlabs/racecapture/views/dashboard/dashboardview.kv
@@ -10,9 +10,10 @@
     			orientation: 'horizontal'
     			IconButton:
     				color: [1.0, 1.0, 1.0, 1.0]
-    				font_size: self.height
+    				font_size: self.height * 1.2
     				text: ' \357\203\231'
-    				size_hint_x: 0.2
+    				size_hint_x: 0.4
+    				size_hint_y: 1.1
     				on_release: root.on_nav_left()
     			DigitalGauge:
     				rcid: 'left_bottom'
@@ -22,9 +23,10 @@
     				rcid: 'right_bottom'
     			IconButton:
     				color: [1.0, 1.0, 1.0, 1.0]
-    				font_size: self.height
+    				font_size: self.height * 1.2
     				text: '\357\203\232 '
-    				size_hint_x: 0.2
+    				size_hint_x: 0.4
+    				size_hint_y: 1.1
     				on_release: root.on_nav_right()
         AnchorLayout:
             anchor_x: 'left'


### PR DESCRIPTION
This change makes the arrows have a nearly 2x as large touch target while still fitting inside their container (afaict). 