### PR TITLE
Allow selecting RC connection type in android app settings

### DIFF
--- a/autosportlabs/comms/commsfactory.py
+++ b/autosportlabs/comms/commsfactory.py
@@ -1,21 +1,36 @@
 from kivy import platform
-if platform == 'android':
-    pass
-elif platform == 'ios':
-    from autosportlabs.comms.socket.socketconnection import SocketConnection
-else:
-    from autosportlabs.comms.serial.serialconnection import SerialConnection
 
-__all__ = ('comms_factory')
+__all__ = 'comms_factory'
 
-def comms_factory(device):
-    if platform == 'android':
-        from autosportlabs.comms.androidcomms import AndroidComms
-        return AndroidComms(device)
-    elif platform == 'ios':
-        from autosportlabs.comms.socket.socketconnection import SocketConnection
-        from autosportlabs.comms.socket.socketcomm import SocketComm
-        return SocketComm(SocketConnection(), device)
+
+def comms_factory(device, conn_type):
+    # Connection type can be overridden by user or for testing purposes
+    if conn_type is not None:
+        if conn_type == 'bluetooth':
+            return android_comm(device)
+        if conn_type == 'wifi':
+            return socket_comm(device)
     else:
-        from autosportlabs.comms.comms import Comms
-        return Comms(device, SerialConnection())
+        if platform == 'android':
+            return android_comm(device)
+        elif platform == 'ios':
+            return socket_comm(device)
+        else:
+            return serial_comm(device)
+
+
+def socket_comm(device):
+    from autosportlabs.comms.socket.socketconnection import SocketConnection
+    from autosportlabs.comms.socket.socketcomm import SocketComm
+    return SocketComm(SocketConnection(), device)
+
+
+def serial_comm(device):
+    from autosportlabs.comms.serial.serialconnection import SerialConnection
+    from autosportlabs.comms.comms import Comms
+    return Comms(device, SerialConnection())
+
+
+def android_comm(device):
+    from autosportlabs.comms.androidcomms import AndroidComms
+    return AndroidComms(device)

--- a/autosportlabs/comms/socket/socketcomm.py
+++ b/autosportlabs/comms/socket/socketcomm.py
@@ -25,6 +25,7 @@ from Queue import Empty
 from time import sleep
 import traceback
 from autosportlabs.comms.commscommon import PortNotOpenException
+from autosportlabs.util.threadutil import safe_thread_exit
 
 
 class SocketComm(object):
@@ -160,6 +161,7 @@ class SocketComm(object):
                 should_run.clear()
                 sleep(0.5)
         Logger.debug('SocketComm: connection process message reader exited')
+        safe_thread_exit()
 
     def _connection_thread_message_writer(self, tx_queue, connection, should_run):
         """This method is designed to be run in a thread, it will loop infinitely as long as should_run.is_set()
@@ -188,6 +190,7 @@ class SocketComm(object):
                 should_run.clear()
                 sleep(0.5)
         Logger.debug('SocketComm: connection thread message writer exited')
+        safe_thread_exit()
 
     def _connection_message_thread(self, connection, address, rx_queue, tx_queue, command_queue):
         """
@@ -243,4 +246,5 @@ class SocketComm(object):
             Logger.debug(traceback.format_exc())
 
         Logger.debug('SocketComm: connection worker exited')
+        safe_thread_exit()
 

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -6,6 +6,7 @@ from time import sleep
 from threading import Thread, RLock, Event
 from autosportlabs.racecapture.config.rcpconfig import *
 from autosportlabs.comms.commscommon import PortNotOpenException, CommsErrorException
+from autosportlabs.util.threadutil import safe_thread_exit, ThreadSafeDict
 from functools import partial
 from kivy.clock import Clock
 from kivy.logger import Logger
@@ -113,7 +114,6 @@ class RcpApi:
         t.start()
         self._cmd_sequence_thread = t
 
-
     def init_api(self, comms):
         self.comms = comms
         self._start_message_rx_worker()
@@ -204,6 +204,7 @@ class RcpApi:
                 else:
                     sleep(0.25)
 
+        safe_thread_exit()
         Logger.info("RCPAPI: msg_rx_worker exiting")
 
     def rcpCmdComplete(self, msgReply):
@@ -325,6 +326,7 @@ class RcpApi:
                 Logger.error('RCPAPI: Execute command exception ' + str(e))
 
         Logger.info('RCPAPI: cmd_sequence_worker exiting')
+        safe_thread_exit()
 
     def sendCommand(self, cmd):
         try:
@@ -732,3 +734,4 @@ class RcpApi:
                 sleep(AUTODETECT_COOLOFF_TIME)
 
         Logger.info('RCPAPI: auto_detect_worker exiting')
+        safe_thread_exit()

--- a/autosportlabs/racecapture/settings/prefs.py
+++ b/autosportlabs/racecapture/settings/prefs.py
@@ -4,6 +4,7 @@ from kivy.clock import Clock
 from kivy.config import ConfigParser
 from ConfigParser import NoOptionError
 from kivy.logger import Logger
+from kivy import platform
 import json
 import os
 from os import path
@@ -99,6 +100,9 @@ class UserPrefs(EventDispatcher):
         self.config.setdefault('preferences', 'send_telemetry', False)
         self.config.setdefault('preferences', 'last_dash_screen', 'gaugeView')
         self.config.setdefault('preferences', 'global_help', True)
+
+        if platform == 'android':
+            self.config.setdefault('preferences', 'conn_type', 'Bluetooth')
 
     def load(self):
         Logger.info('UserPrefs: Data Dir is: {}'.format(self.data_dir))

--- a/autosportlabs/racecapture/status/statuspump.py
+++ b/autosportlabs/racecapture/status/statuspump.py
@@ -4,7 +4,7 @@ from kivy.logger import Logger
 from kivy.clock import Clock
 from time import sleep
 from threading import Thread, Event
-
+from autosportlabs.util.threadutil import safe_thread_exit
 
 
 """Responsible for querying status from the RaceCapture API
@@ -44,7 +44,8 @@ class StatusPump(object):
     def stop(self):
         self._running.clear()
         try:
-            self._status_thread.join()
+            if self._status_thread:
+                self._status_thread.join()
         except Exception as e:
             Logger.warn('StatusPump: failed to join status_worker: {}'.format(e))
 
@@ -54,7 +55,8 @@ class StatusPump(object):
         while self._running.is_set():
             self._rc_api.get_status()
             sleep(self.STATUS_QUERY_INTERVAL)
-        Logger.info('StatusPump: status_worker exiting')
+        Logger.info('StatusPump: status_worker exited')
+        safe_thread_exit()
 
     def _update_all_listeners(self, status):
         for listener in self._listeners:

--- a/resource/settings/android_settings.json
+++ b/resource/settings/android_settings.json
@@ -2,7 +2,7 @@
     {
         "type": "options",
         "title": "RaceCapture connection type",
-        "desc": "Connection type to your RaceCapture hardware",
+        "desc": "Connection type to your RaceCapture system",
         "section": "preferences",
         "key": "conn_type",
         "true": "auto",

--- a/resource/settings/android_settings.json
+++ b/resource/settings/android_settings.json
@@ -1,0 +1,11 @@
+[
+    {
+        "type": "options",
+        "title": "RaceCapture connection type",
+        "desc": "Connection type to your RaceCapture hardware",
+        "section": "preferences",
+        "key": "conn_type",
+        "true": "auto",
+        "options": ["Bluetooth", "WiFi"]
+    }
+]


### PR DESCRIPTION
This PR allows android users to select the connection type for their RC device via the app settings.  Refactored comms_factory, added safe_thread_exit to a lot of threads for android, restart comms if connection type changes and added selector to app preferences.