### PR TITLE
Change socket connection to read only one line/message at a time when reading data

### DIFF
--- a/autosportlabs/comms/socket/socketcomm.py
+++ b/autosportlabs/comms/socket/socketcomm.py
@@ -153,7 +153,7 @@ class SocketComm(object):
 
         while should_run.is_set():
             try:
-                msg = connection.read(should_run)
+                msg = connection.read_line(should_run)
                 if msg:
                     rx_queue.put(msg)
             except:

--- a/autosportlabs/comms/socket/socketconnection.py
+++ b/autosportlabs/comms/socket/socketconnection.py
@@ -31,6 +31,7 @@ class SocketConnection(object):
 
     def __init__(self):
         self.socket = None
+        self._data = ''
 
     def get_available_devices(self):
         """
@@ -87,7 +88,7 @@ class SocketConnection(object):
         self.socket.close()
         self.socket = None
 
-    def read(self, keep_reading):
+    def read_line(self, keep_reading):
         """
         Reads data from the socket. Will continue to read until either "\r\n" is found in the data read from the
         socket or keep_reading.is_set() returns false
@@ -95,7 +96,6 @@ class SocketConnection(object):
         :type keep_reading: threading.Event
         :return: String or None
         """
-        msg = ''
         Logger.info("SocketConnection: reading...")
 
         while keep_reading.is_set():
@@ -104,14 +104,16 @@ class SocketConnection(object):
                 if data == '':
                     return None
 
-                msg += data
+                self._data += data
 
-                if msg[-2:] == '\r\n':
-                    if msg != '':
-                        Logger.info("SocketConnection: returning data {}".format(msg))
-                        return msg
-                    else:
-                        return None
+                if '\r\n' in self._data:
+                    lines = self._data.split('\r\n', 1)
+                    msg = lines[0]
+                    self._data = lines[1]
+
+                    Logger.info("SocketConnection: returning data {}".format(msg))
+                    return msg
+
             except socket.timeout:
                 pass
 

--- a/autosportlabs/comms/socket/socketconnection.py
+++ b/autosportlabs/comms/socket/socketconnection.py
@@ -111,7 +111,7 @@ class SocketConnection(object):
                     msg = lines[0]
                     self._data = lines[1]
 
-                    Logger.info("SocketConnection: returning data {}".format(msg))
+                    Logger.debug("SocketConnection: returning data {}".format(msg))
                     return msg
 
             except socket.timeout:


### PR DESCRIPTION
It turns out that reading data from a socket isn't the same as reading data from USB. This PR makes a slight change to the socket connection code. Now when the socket connection is asked to read, it will only read one line, then return that data, leaving any extra data behind for use later.

Simple fix, seems to make socket comms stuff work well.