### PR TITLE
Datastore security and fixes

### DIFF
--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -230,6 +230,7 @@ class Filter(object):
     @add_combop
     def group(self, filterchain):
         self._cmd_seq += '({})'.format(str(filterchain).strip())
+        self.params = self.params + filterchain.params
         return self
 
 
@@ -730,12 +731,12 @@ class DataStore(object):
         
     def get_channel_average(self, channel, sessions=None):
         c = self._conn.cursor()
-        params = [channel]
+        params = []
 
         if sessions is not None:
             params = params + sessions
 
-        base_sql = "SELECT AVG(?) from datapoint " + self._session_select_clause(sessions)
+        base_sql = "SELECT AVG({}) from datapoint ".format(self._scrub_sql_value(channel)) + self._session_select_clause(sessions)
         c.execute(base_sql, params)
         res = c.fetchone()
         average = None if res == None else res[0]

--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -903,7 +903,7 @@ class DataStore(object):
         #Put together the smoothing map
         for ch in channels:
             sr = self.get_channel_smoothing(ch)
-            smoothing_map[ch] = sr
+            smoothing_map[self._scrub_sql_value(ch)] = sr
 
         #add the session_id to the smoothing map with a smoothing rate
         #of 0

--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -151,6 +151,7 @@ class Filter(object):
         self._cmd_seq = ''
         self._comb_op = 'AND '
         self._channels = []
+        self.params = []
 
     @property
     def channels(self):
@@ -176,37 +177,43 @@ class Filter(object):
     @add_combop
     @chan_adj
     def neq(self, chan, val):
-        self._cmd_seq += '{} != {} '.format(chan, val)
+        self._cmd_seq += '{} != ? '.format(chan, val)
+        self.params.append(val)
         return self
 
     @add_combop
     @chan_adj
     def eq(self, chan, val):
-        self._cmd_seq += '{} = {} '.format(chan, val)
+        self._cmd_seq += '{} = ? '.format(chan, val)
+        self.params.append(val)
         return self
 
     @add_combop
     @chan_adj
     def lt(self, chan, val):
-        self._cmd_seq += '{} < {} '.format(chan, val)
+        self._cmd_seq += '{} < ? '.format(chan, val)
+        self.params.append(val)
         return self
 
     @add_combop
     @chan_adj
     def gt(self, chan, val):
-        self._cmd_seq += '{} > {} '.format(chan, val)
+        self._cmd_seq += '{} > ? '.format(chan, val)
+        self.params.append(val)
         return self
 
     @add_combop
     @chan_adj
     def lteq(self, chan, val):
-        self._cmd_seq += '{} <= {} '.format(chan, val)
+        self._cmd_seq += '{} <= ? '.format(chan, val)
+        self.params.append(val)
         return self
 
     @add_combop
     @chan_adj
     def gteq(self, chan, val):
-        self._cmd_seq += '{} >= {} '.format(chan, val)
+        self._cmd_seq += '{} >= ? '.format(chan, val)
+        self.params.append(val)
         return self
 
     def and_(self):
@@ -219,7 +226,6 @@ class Filter(object):
 
     def __str__(self):
         return self._cmd_seq
-        return self
 
     @add_combop
     def group(self, filterchain):
@@ -239,6 +245,7 @@ class DatalogChannel(object):
         return self.name
 
 class DataStore(object):
+    # Channels to index on, WARNING: only [A-z] channel names with no spaces will work currently
     EXTRA_INDEX_CHANNELS = ["CurrentLap"]    
     val_filters = ['lt', 'gt', 'eq', 'lt_eq', 'gt_eq']
     def __init__(self):
@@ -347,13 +354,15 @@ class DataStore(object):
 
         self._conn.commit()
 
+    def _scrub_sql_value(self,value):
+        return ''.join(chr for chr in value if chr.isalnum())
     
     def _add_extra_indexes(self, channels):
         extra_indexes = []
         for c in channels:
             c = str(c)
             if c in self.EXTRA_INDEX_CHANNELS:
-                extra_indexes.append(c)
+                extra_indexes.append(self._scrub_sql_value(c))
         
         for index_channel in extra_indexes:
             self._conn.execute("""CREATE INDEX {}_index_id on datapoint({})""".format(index_channel, index_channel))
@@ -363,7 +372,7 @@ class DataStore(object):
             #Extend the datapoint table to include the channel as a
             #new field
             self._conn.execute("""ALTER TABLE datapoint
-            ADD {} REAL""".format(channel.name))
+            ADD {} REAL""".format(self._scrub_sql_value(channel.name)))
 
             #Add the channel to the 'channel' table
             self._conn.execute("""INSERT INTO channel (name, units, min_value, max_value, smoothing)
@@ -429,14 +438,14 @@ class DataStore(object):
     
             #Insert the datapoints into their tables
             extrap_vals = [datalog_id] + record
-    
+
             #Now, insert the record into the datalog table using the ID
             #list we built up in the previous iteration
     
             #Put together an insert statement containing the column names
-            base_sql = "INSERT INTO datapoint ({}) VALUES({});".format(','.join(['sample_id'] + [x.name for x in channels]), 
-                                                                       ','.join([str(x) for x in extrap_vals]))
-            cursor.execute(base_sql)
+            base_sql = "INSERT INTO datapoint ({}) VALUES({});".format(','.join(['sample_id'] + [self._scrub_sql_value(x.name) for x in channels]),
+                                                                       ','.join(['?'] * (len(extrap_vals) + 1)))
+            cursor.execute(base_sql, extrap_vals)
             self._conn.commit()
         except: #rollback under any exception, then re-raise exception
             self._conn.rollback()
@@ -675,7 +684,7 @@ class DataStore(object):
         newdata_gen = self._desparsified_data_generator(data_file, warnings=warnings, progress_cb=progress_cb)
 
         #Put together an insert statement containing the column names
-        datapoint_sql = "INSERT INTO datapoint ({}) VALUES ({});".format(','.join(['sample_id'] + [x.name for x in headers]), 
+        datapoint_sql = "INSERT INTO datapoint ({}) VALUES ({});".format(','.join(['sample_id'] + [ self._scrub_sql_value(x.name) for x in headers]),
                                                                          ','.join(['?'] * (len(headers) + 1)))
 
         #Relatively static insert statement for sample table
@@ -695,11 +704,13 @@ class DataStore(object):
         c = self._conn.cursor()
 
         base_sql = 'SELECT AVG(Latitude), AVG(Longitude) from datapoint'
+        params = ','.join(['?'] * (len(sessions)))
         
         if type(sessions) == list and len(sessions) > 0:
-            base_sql += ' JOIN sample ON datapoint.sample_id=sample.id WHERE sample.session_id IN({}) AND datapoint.Latitude != 0 AND datapoint.Longitude != 0;'.format(','.join(map(str, sessions)))
+            base_sql += """ JOIN sample ON datapoint.sample_id=sample.id WHERE sample.session_id IN({}) AND
+            datapoint.Latitude != 0 AND datapoint.Longitude != 0""".format(params)
 
-        c.execute(base_sql)
+        c.execute(base_sql, sessions)
         res = c.fetchone()
         
         lat_average = None
@@ -712,14 +723,20 @@ class DataStore(object):
     def _session_select_clause(self, sessions=None):
         sql = ''
         if type(sessions) == list and len(sessions) > 0:
-            sql += ' JOIN sample ON datapoint.sample_id=sample.id WHERE sample.session_id IN({})'.format(','.join(map(str, sessions)))            
+            subs = ','.join(['?'] * len(sessions))
+
+            sql += ' JOIN sample ON datapoint.sample_id=sample.id WHERE sample.session_id IN({})'.format(subs)
         return sql
         
     def get_channel_average(self, channel, sessions=None):
         c = self._conn.cursor()
+        params = [channel]
 
-        base_sql = "SELECT AVG({}) from datapoint {};".format(channel, self._session_select_clause(sessions))
-        c.execute(base_sql)
+        if sessions is not None:
+            params = params + sessions
+
+        base_sql = "SELECT AVG(?) from datapoint " + self._session_select_clause(sessions)
+        c.execute(base_sql, params)
         res = c.fetchone()
         average = None if res == None else res[0]
         return average
@@ -728,17 +745,24 @@ class DataStore(object):
         sql = ''
         if type(extra_channels) == list:
             for channel in extra_channels:
-                sql += ',{}'.format(channel)
+                sql += ',{}'.format(self._scrub_sql_value(channel))
         return sql
 
     def _get_channel_aggregate(self, aggregate, channel, sessions=None, extra_channels=None, exclude_zero=True):
         c = self._conn.cursor()
+        params = []
 
-        base_sql = "SELECT {}({}) {} from datapoint {} {};".format(aggregate, channel,
+        if sessions is not None:
+            params = params + sessions
+
+        base_sql = "SELECT {}({}) {} from datapoint {} {};".format(aggregate, self._scrub_sql_value(channel),
                                                                  self._extra_channels(extra_channels),
                                                                  self._session_select_clause(sessions),
-                                                                 '{} {} > 0'.format('AND' if sessions else 'WHERE', channel) if exclude_zero else '')
-        c.execute(base_sql)
+                                                                 '{} {} > 0'.format('AND' if sessions else 'WHERE',
+                                                                                    self._scrub_sql_value(channel))
+                                                                   if exclude_zero else '')
+
+        c.execute(base_sql, params)
         res = c.fetchone()
         return None if res == None else res if extra_channels else res[0]
                 
@@ -764,10 +788,9 @@ class DataStore(object):
         if not channel in [x.name for x in self._channels]:
             raise DatastoreException("Unknown channel: {}".format(channel))
 
-        self._conn.execute("""UPDATE channel
-        SET smoothing={}
-        WHERE name='{}'
-        """.format(smoothing, channel))
+        params = [smoothing, channel]
+
+        self._conn.execute('UPDATE channel SET smoothing = ? WHERE name = ?', params)
 
     def get_channel_smoothing(self, channel):
         if not channel in [x.name for x in self._channels]:
@@ -775,8 +798,8 @@ class DataStore(object):
 
         c = self._conn.cursor()
 
-        base_sql = "SELECT smoothing from channel WHERE channel.name='{}';".format(channel)
-        c.execute(base_sql)
+        base_sql = "SELECT smoothing from channel WHERE channel.name=?;"
+        c.execute(base_sql, [channel])
 
         res = c.fetchone()
 
@@ -815,6 +838,7 @@ class DataStore(object):
 
         columns = []
         joins = []
+        params = []
 
         #make sure that the sessions list exists
         if type(sessions) != list or len(sessions) == 0:
@@ -823,12 +847,10 @@ class DataStore(object):
         #If there are no channels, or if a '*' is passed, select all
         #of the channels
         if len(channels) == 0 or '*' in channels:
-            channels = [x.chan_name for x in self._channels]
+            channels = [self._scrub_sql_value(x.chan_name) for x in self._channels]
 
         for ch in channels:
-            if not ch in [x.name for x in self._channels]:
-                raise DatastoreException("Unable to complete query. Unknown channel: {}".format(ch))
-            chanst = str(ch)
+            chanst = str(self._scrub_sql_value(ch))
             tbl_prefix = 'datapoint.'
             alias = ' as {}'.format(chanst)
             columns.append(tbl_prefix+chanst+alias)
@@ -854,6 +876,7 @@ class DataStore(object):
                 raise TypeError("data_filter must be of class Filter")
 
             sel_st += str(data_filter)
+            params = params + data_filter.params
 
         #create the session filter
         if data_filter == None:
@@ -863,7 +886,8 @@ class DataStore(object):
             
         ses_filters = []
         for s in sessions:
-            ses_filters.append('sample.session_id = {}'.format(s))
+            ses_filters.append('sample.session_id = ?')
+            params.append(s)
 
         ses_st += 'OR '.join(ses_filters)
 
@@ -872,7 +896,7 @@ class DataStore(object):
 
         Logger.debug('[datastore] Query execute: {}'.format(sel_st))
         c = self._conn.cursor()
-        c.execute(sel_st)
+        c.execute(sel_st, params)
 
         smoothing_map = {}
         #Put together the smoothing map
@@ -939,7 +963,7 @@ class DataStore(object):
         cursor = self._conn.cursor()
         channels_to_update = [x for x in self._channels if channels is None or x.name in channels]
         for channel in channels_to_update:
-            name = channel.name
+            name = self._scrub_sql_value(channel.name)
             min_max = cursor.execute('SELECT COALESCE(MIN({}), 0), COALESCE(MAX({}), 0) FROM datapoint;'.format(name, name))
             record = min_max.fetchone()
             datapoint_min_value = record[0]

--- a/test/autosportlabs/racecapture/datastore/test_datastore.py
+++ b/test/autosportlabs/racecapture/datastore/test_datastore.py
@@ -51,34 +51,38 @@ class DataStoreTest(unittest.TestCase):
     def test_basic_filter(self):
         f = Filter().lt('LapCount', 1)
 
-        expected_output = 'datapoint.LapCount < 1'
+        expected_output = 'datapoint.LapCount < ?'
         filter_text = str(f).strip()
 
         self.assertSequenceEqual(filter_text, expected_output)
+        self.assertListEqual(f.params, [1])
 
     def test_not_equal_filter(self):
         f = Filter().neq('LapCount', 1)
         
-        expected_output = 'datapoint.LapCount != 1'
+        expected_output = 'datapoint.LapCount != ?'
         filter_text = str(f).strip()
         
         self.assertSequenceEqual(filter_text, expected_output)
+        self.assertListEqual(f.params, [1])
         
     def test_chained_filter(self):
         f = Filter().lt('LapCount', 1).gt('Coolant', 212).or_().eq('RPM', 9001)
 
-        expected_output = 'datapoint.LapCount < 1 AND datapoint.Coolant > 212 OR datapoint.RPM = 9001'
+        expected_output = 'datapoint.LapCount < ? AND datapoint.Coolant > ? OR datapoint.RPM = ?'
         filter_text = str(f).strip()
 
         self.assertSequenceEqual(filter_text, expected_output)
+        self.assertListEqual(f.params, [1, 212, 9001])
 
     def test_grouped_filter(self):
         f = Filter().lt('LapCount', 1).group(Filter().gt('Coolant', 212).or_().gt('RPM', 9000))
 
-        expected_output = 'datapoint.LapCount < 1 AND (datapoint.Coolant > 212 OR datapoint.RPM > 9000)'
+        expected_output = 'datapoint.LapCount < ? AND (datapoint.Coolant > ? OR datapoint.RPM > ?)'
         filter_text = str(f).strip()
 
         self.assertSequenceEqual(filter_text, expected_output)
+        self.assertListEqual(f.params, [1, 212, 9000])
 
     def test_dataset_columns(self):
         f = Filter().lt('LapCount', 1)


### PR DESCRIPTION
This PR does 2 major things:

1. Fixes #901 , spaces in channel names break importing data to the app
2. Scrubs channel names used for SQL column names and changes all queries to use parameterized values for additional SQL security.