### PR TITLE
Detect if RC firmware didn't find a track and add it automagically to the config so it JUST WORKS

### DIFF
--- a/autosportlabs/racecapture/tracks/trackhelper.py
+++ b/autosportlabs/racecapture/tracks/trackhelper.py
@@ -1,0 +1,165 @@
+from datetime import datetime
+from autosportlabs.racecapture.geo.geopoint import GeoPoint
+from kivy.logger import Logger
+from kivy.event import EventDispatcher
+from autosportlabs.racecapture.config.rcpconfig import *
+
+
+class TrackHelper(EventDispatcher):
+    """
+    This class' responsibility is to make sure RC detects a track when it runs so
+    users get lap timing when they are on track
+    """
+
+    def __init__(self, track_manager, rc_api, status_pump, rc_config, **kwargs):
+        """
+        Init!
+        :param track_manager: TrackManager instance
+        :param rc_api: RCAPI instance
+        :param status_pump: StatusPump instance
+        :param rc_config: RCConfig instance
+        :param kwargs: kwargs
+        :return: None
+        """
+        self.register_event_type('on_track_detected')
+        super(TrackHelper, self).__init__(**kwargs)
+
+        self.track_manager = track_manager
+        self.rc_api = rc_api
+        self.status_pump = status_pump
+        self.rc_config = rc_config
+
+        # Number of seconds to wait until we attempt to figure out what track we're at,
+        # allows RC hardware some time to detect a track
+        self._wait_period = 4
+
+        #When RC was ready, we wait _wait_period after this to ensure RC had time to search for a track
+        self._ready_start_time = None
+
+        #Status hash from StatusPump
+        self._status = None
+
+        #Has the TrackManager loaded all tracks?
+        self._tracks_loaded = False
+
+        #Did RC detect a track?
+        self._track_detected = False
+
+        self.status_pump.add_listener(self.on_status)
+
+        if len(self.track_manager.tracks) == 0:
+            self.track_manager.load_tracks(success_cb=self._on_tracks_loaded, fail_cb=self._on_tracks_load_fail)
+            Logger.info("TrackHelper: Loading tracks")
+        else:
+            self._tracks_loaded = True
+
+        Logger.debug("TrackHelper: initialized")
+
+    def on_track_detected(self):
+        """
+        Dispatched when track found in track db
+        :return:
+        """
+        pass
+
+    def on_status(self, status):
+        """
+        StatusPump status listener
+        :param status: Status hash
+        :return: None
+        """
+        self._status = status['status']
+        self._track_detected = self._status['track']['status'] != 0
+
+        self._check_track_detection()
+
+    def _on_tracks_loaded(self):
+        """
+        Callback for when TrackManager loads tracks
+        :return: None
+        """
+        self._tracks_loaded = True
+        Logger.info("TrackHelper: tracks loaded")
+
+    def _on_tracks_load_fail(self):
+        """
+        Callback for when TrackManager fails to load tracks
+        :return: None
+        """
+        Logger.error("TrackHelper: track load failed")
+
+    def _is_ready(self):
+        """
+        Determines if all preconditions for searching for a track are met
+            1) RC has *not* detected a track
+            2) GPS is initialized and has a quality signal
+            3) We've waited a short amount of time to allow RC to search for a track
+            4) TrackManager has loaded tracks
+            5) RC config has tracks
+        :return: Boolean
+        """
+        if self._track_detected:
+            Logger.info("TrackHelper: track detected, aborting")
+            return False
+
+        if self._status['GPS']['init'] != 1 and self._status['GPS']['qual'] < 2:
+            Logger.info("TrackHelper: GPS not initialized or signal strength not high enough, aborting")
+            return False
+
+        if not self._ready_start_time:
+            Logger.info("TrackHelper: waiting for RC warmup")
+            self._ready_start_time = datetime.now()
+            return False
+
+        diff = datetime.now() - self._ready_start_time
+
+        if diff.total_seconds() < self._wait_period:
+            Logger.info("TrackHelper: waiting for RC warmup")
+            return False
+
+        if not self._tracks_loaded or not self.rc_config.trackConfig:
+            return False
+
+        return True
+
+    def _check_track_detection(self):
+        """
+        If everything is ready, attempt to find a track in the app's local track db that is near
+        where RC is now. Uses the track manager to find a track, if found adds it to RC Config's
+        track db and fires the 'on_track_detected' event
+        :return:
+        """
+        if self._is_ready():
+            # Ok we are ready to go!
+
+            Logger.info("TrackHelper: attempting to find track")
+
+            geopoint = GeoPoint()
+            geopoint.latitude = self._status['GPS']['lat']
+            geopoint.longitude = self._status['GPS']['lon']
+
+            track = self.track_manager.find_nearby_track(geopoint)
+
+            if track:
+                # Hooray!
+                Logger.info("TrackHelper: found a track, adding it to RC config: {}".format(track.track_id))
+
+                track_to_add = Track.fromTrackMap(track)
+
+                # First, check if it's already in RC's config
+                previously_added = [t for t in self.rc_config.trackDb.tracks if t.trackId == track_to_add.trackId]
+
+                if len(previously_added) > 0:
+                    Logger.info("TrackHelper: track found already in RC config, not adding")
+                    return
+
+                self.rc_config.trackDb.tracks.append(track_to_add)
+                self.rc_config.trackDb.stale = True
+                self.dispatch("on_track_detected")
+            else:
+                Logger.info("TrackHelper: no track found")
+        else:
+            Logger.info("TrackHelper: RC track detected or GPS not ready for track detection")
+
+
+

--- a/autosportlabs/racecapture/tracks/trackhelper.py
+++ b/autosportlabs/racecapture/tracks/trackhelper.py
@@ -49,7 +49,7 @@ class TrackHelper(EventDispatcher):
 
         if len(self.track_manager.tracks) == 0:
             self.track_manager.load_tracks(success_cb=self._on_tracks_loaded, fail_cb=self._on_tracks_load_fail)
-            Logger.info("TrackHelper: Loading tracks")
+            Logger.debug("TrackHelper: Loading tracks")
         else:
             self._tracks_loaded = True
 
@@ -79,7 +79,7 @@ class TrackHelper(EventDispatcher):
         :return: None
         """
         self._tracks_loaded = True
-        Logger.info("TrackHelper: tracks loaded")
+        Logger.debug("TrackHelper: tracks loaded")
 
     def _on_tracks_load_fail(self):
         """
@@ -99,22 +99,22 @@ class TrackHelper(EventDispatcher):
         :return: Boolean
         """
         if self._track_detected:
-            Logger.info("TrackHelper: track detected, aborting")
+            Logger.debug("TrackHelper: track detected, aborting")
             return False
 
         if self._status['GPS']['init'] != 1 and self._status['GPS']['qual'] < 2:
-            Logger.info("TrackHelper: GPS not initialized or signal strength not high enough, aborting")
+            Logger.debug("TrackHelper: GPS not initialized or signal strength not high enough, aborting")
             return False
 
         if not self._ready_start_time:
-            Logger.info("TrackHelper: waiting for RC warmup")
+            Logger.debug("TrackHelper: waiting for RC warmup")
             self._ready_start_time = datetime.now()
             return False
 
         diff = datetime.now() - self._ready_start_time
 
         if diff.total_seconds() < self._wait_period:
-            Logger.info("TrackHelper: waiting for RC warmup")
+            Logger.debug("TrackHelper: waiting for RC warmup")
             return False
 
         if not self._tracks_loaded or not self.rc_config.trackConfig:
@@ -159,7 +159,7 @@ class TrackHelper(EventDispatcher):
             else:
                 Logger.info("TrackHelper: no track found")
         else:
-            Logger.info("TrackHelper: RC track detected or GPS not ready for track detection")
+            Logger.debug("TrackHelper: RC track detected or GPS not ready for track detection")
 
 
 

--- a/autosportlabs/racecapture/tracks/trackmanager.py
+++ b/autosportlabs/racecapture/tracks/trackmanager.py
@@ -181,8 +181,8 @@ class TrackManager:
         radius = point.metersToDegrees(searchRadius, searchBearing)
         for trackId in self.tracks.keys():
             track = self.tracks[trackId]
-            trackCenter = track.centerpoint
-            if trackCenter and trackCenter.withinCircle(point, radius):
+            start_finish = track.start_finish_point
+            if start_finish.latitude and start_finish.longitude and start_finish.withinCircle(point, radius):
                 return track
         return None
 

--- a/autosportlabs/racecapture/views/configuration/rcp/configview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/configview.py
@@ -102,6 +102,14 @@ class ConfigView(Screen):
         self.rc_config = config
         self.update_config_views()
 
+    def on_track_added(self):
+        self._notify_track_added()
+
+    def _notify_track_added(self):
+        for view in self.configViews:
+            if hasattr(view, 'on_track_added'):
+                view.on_track_added()
+
     def on_track_manager(self, instance, value):
         self.update_tracks()
 

--- a/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/trackconfigview.py
@@ -220,12 +220,15 @@ class AutomaticTrackConfigScreen(Screen):
                 
     def on_config_updated(self, rcpCfg):
         self.trackDb = rcpCfg.trackDb
-        self.init_tracks_list()
+        self.draw_tracks_list()
         
     def on_track_manager(self, instance, value):
         self.track_manager = value
-        self.init_tracks_list()
-    
+        self.draw_tracks_list()
+
+    def on_track_added(self):
+        self.draw_tracks_list()
+
     def on_tracks_selected(self, instance, selectedTrackIds):
         if self.trackDb:
             failures = False
@@ -241,7 +244,7 @@ class AutomaticTrackConfigScreen(Screen):
                         failures = True
             if failures:
                 alertPopup('Cannot Add Tracks', 'One or more tracks could not be added due to missing start/finish points.\n\nPlease check for track map updates and try again.')            
-            self.init_tracks_list()
+            self.draw_tracks_list()
             self.trackSelectionPopup.dismiss()
             self.trackDb.stale = True
             self.dispatch('on_modified')
@@ -253,7 +256,7 @@ class AutomaticTrackConfigScreen(Screen):
         popup.open()
         self.trackSelectionPopup = popup
     
-    def init_tracks_list(self):
+    def draw_tracks_list(self):
         if self.track_manager and self.trackDb:
             matchedTracks = []
             for track in self.trackDb.tracks:
@@ -282,7 +285,7 @@ class AutomaticTrackConfigScreen(Screen):
     def on_remove_track(self, instance, index):
             try:
                 del self.trackDb.tracks[index]
-                self.init_tracks_list()
+                self.draw_tracks_list()
                 self.trackDb.stale = True
                 self.dispatch('on_modified')
                             
@@ -410,6 +413,9 @@ class TrackConfigView(BaseConfigView):
         autoDetect.setControl(SettingsSwitch())
         
         self.autoConfigView.track_manager = kwargs.get('track_manager')
+
+    def on_track_added(self):
+        self.autoConfigView.on_track_added()
 
     def on_tracks_updated(self, track_manager):
         self.autoConfigView.track_manager = track_manager


### PR DESCRIPTION
Shazam!

* Our users often forget to set their track configs
* Our competition automatically includes the most common tracks in their systems,
* Users shouldn't have to remember to configure their system when it's 2016 and we have the tools and capabilities to handle doing basic searching over a few hundred track locations.

This PR does one thing and does it well. It watches RC hardware when connected and if after all preconditions are met (GPS lock, RC connected, no track detected, tracks loaded in app, etc) it will try to find a nearby track and push it to the connected RC device so lap timing works.

Thing that need help/review:

- How the heck do we sync configuration changes between multiple components? The TrackHelper object is modifying the RC Config tracks db, so if you are viewing/editing your RC configuration and the TrackHelper finds your track, the config view needs to update. My current method is hacky. Ideally I want events to fire *from* the RC config so when it changes, everything is notified. This is problematic if something is listening for changes and making changes at the same time.