### PR TITLE
Remove tracks menu item

### DIFF
--- a/autosportlabs/racecapture/menu/homepageview.kv
+++ b/autosportlabs/racecapture/menu/homepageview.kv
@@ -48,8 +48,3 @@
 				icon: '\357\202\205'
 				title: 'Configuration'
 				on_press: root.show_view('config')
-			FeatureButton:
-				icon: '\357\200\230'
-				title: 'Race Tracks'
-				on_press: root.show_view('tracks')
-			

--- a/autosportlabs/racecapture/menu/homepageview.kv
+++ b/autosportlabs/racecapture/menu/homepageview.kv
@@ -17,7 +17,6 @@
 				size_hint: 1.0, 0.1
 				anchor_x: 'left'
 				anchor_y: 'center'
-
 				Image:
 					source: 'resource/images/app_icon_menu.png'
 					size_hint_x: None	
@@ -31,20 +30,25 @@
 					font_name: 'resource/fonts/ASL_regular.ttf'
 					pos_hint: {'center_y':0.57}
 					text: 'Welcome To RaceCapture'
-		GridLayout:
+		BoxLayout:
+			size_hint_x: 0.7
+			orientation: 'vertical'
 			padding: [self.height * 0.05, self.height * 0.05]
-			spacing: self.height * 0.025
-			rows: 2
-			cols: 2
+			spacing: dp(15)
 			FeatureButton:
 				icon: '\357\203\244'
-				title: 'Dashboard'
+				title: 'Race'
 				on_press: root.show_view('dash')
-			FeatureButton:
-				icon: '\357\202\200'
-				title: 'Analysis'
-				on_press: root.show_view('analysis')				
-			FeatureButton:
-				icon: '\357\202\205'
-				title: 'Configuration'
-				on_press: root.show_view('config')
+            GridLayout:
+            	rows: 1
+				spacing: dp(15)
+				height: dp(200)
+				size_hint_y: None
+                FeatureButton:
+                    icon: '\357\202\200'
+                    title: 'Analysis'
+                    on_press: root.show_view('analysis')
+                FeatureButton:
+                    icon: '\357\202\205'
+                    title: 'Configuration'
+                    on_press: root.show_view('config')

--- a/autosportlabs/racecapture/menu/mainmenu.kv
+++ b/autosportlabs/racecapture/menu/mainmenu.kv
@@ -44,11 +44,6 @@
             description: 'Configuration'
             on_main_menu_item_selected: root.on_main_menu_item_selected(*args)		
         MainMenuItem:
-            rcid: 'tracks'
-            icon: '\357\200\230'
-            description: 'Race Tracks'
-            on_main_menu_item_selected: root.on_main_menu_item_selected(*args)		
-        MainMenuItem:
             rcid: 'preferences'
             icon: '\357\200\207'
             description: 'Preferences'

--- a/main.py
+++ b/main.py
@@ -35,7 +35,6 @@ if __name__ == '__main__':
     from kivy.uix.screenmanager import *
     from installfix_garden_navigationdrawer import NavigationDrawer
     from autosportlabs.racecapture.views.util.alertview import alertPopup, confirmPopup
-    from autosportlabs.racecapture.views.tracks.tracksview import TracksView
     from autosportlabs.racecapture.views.configuration.rcp.configview import ConfigView
     from autosportlabs.racecapture.views.status.statusview import StatusView
     from autosportlabs.racecapture.views.dashboard.dashboardview import DashboardView
@@ -294,11 +293,6 @@ class RaceCaptureApp(App):
         self.tracks_listeners.append(status_view)
         return status_view
 
-    def build_tracks_view(self):
-        tracks_view = TracksView(name='tracks', track_manager=self.trackManager)
-        self.tracks_listeners.append(tracks_view)
-        return tracks_view
-
     def build_dash_view(self):
         dash_view = DashboardView(name='dash', dataBus=self._databus, settings=self.settings)
         self.tracks_listeners.append(dash_view)
@@ -321,7 +315,6 @@ class RaceCaptureApp(App):
 
     def init_view_builders(self):
         self.view_builders = {'config': self.build_config_view,
-                              'tracks': self.build_tracks_view,
                               'dash': self.build_dash_view,
                               'analysis': self.build_analysis_view,
                               'preferences': self.build_preferences_view,


### PR DESCRIPTION
To remove any confusion as to how a user adds tracks to RCP, this PR removes the homepage and menu items that would take you to the tracks manager. Now, you only can update and select tracks in the configuration screen.

Also changes 'Dashboard' to 'Race' on the homepage view, a step in the direction of a 'race' mode that will allow the app to know that the user is heading on to the track and to do a final check of all requirements.