### PR TITLE
Fix Bluetooth layout bugs, advanced BT config layout and spinner heights

### DIFF
--- a/autosportlabs/racecapture/views/configuration/rcp/advancedbluetoothconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/advancedbluetoothconfigview.py
@@ -32,28 +32,27 @@ from autosportlabs.uix.bettertextinput import BetterTextInput
 
 CONFIG_VIEW = '''
 <AdvancedBluetoothConfigView>
-    cols: 1
     Label:
         text: "NOTE: current values not shown. Enter new values to change settings. Changes will take affect after restarting RaceCapture."
-        text_size: self.size
-        size: self.texture_size
-        size_hint_y: 0.2
+        text_size: root.width, None
+        size_hint_y: None
+        height: self.texture_size[1]
+        padding: [dp(10), dp(10)]
     GridLayout:
         cols: 1
+        spacing: dp(10)
         SettingsView:
             id: name
             label_text: 'New Name'
             help_text: 'Minimum 1 character'
-            size_hint_y: 0.3
         SettingsView:
             id: passkey
             label_text: 'New Passcode'
             help_text: '4 digits required'
-            size_hint_y: 0.3
 '''
 
 
-class AdvancedBluetoothConfigView(GridLayout):
+class AdvancedBluetoothConfigView(StackLayout):
     """
     Advanced Bluetooth configuration for name and passkey. For RCP Mk2, the configuration cannot be read and new
     configuration will take affect after a power cycle.

--- a/autosportlabs/racecapture/views/configuration/rcp/wireless/bluetoothconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/wireless/bluetoothconfigview.py
@@ -14,19 +14,16 @@ Builder.load_string('''
     id: bluetooth
     cols: 1
     spacing: [0, dp(20)]
-    row_default_height: dp(40)
     size_hint: [1, None]
     height: self.minimum_height
     HSeparator:
-        size_hint_y: 0.5
         text: 'Bluetooth'
+        size_hint_y: None
     SettingsView:
         id: bt_enable
         label_text: 'Bluetooth'
         help_text: 'If the Bluetooth module is connected, enable it here'
-        size_hint_y: 1
     SettingsView:
-        size_hint_y: 0.15
         id: btconfig
         label_text: 'Advanced configuration'
         help_text: 'Change Bluetooth name and passkey. Firmware version 2.9.0 or greater required.'

--- a/autosportlabs/racecapture/views/configuration/rcp/wireless/cellularconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/wireless/cellularconfigview.py
@@ -24,7 +24,7 @@ Builder.load_string('''
         label_text: 'Cellular Module'
         help_text: 'Enable if the Real-time telemetry module is installed'
     SettingsView:
-        size_hint_y: 0.5
+        size_hint_y: None
         rcid: 'cellprovider'
         label_text: 'Cellular Provider'
         help_text: 'Select the cellular provider, or specify custom APN settings'

--- a/autosportlabs/racecapture/views/configuration/rcp/wireless/wificonfigview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/wireless/wificonfigview.py
@@ -93,11 +93,9 @@ Builder.load_string('''
     SettingsView:
         id: ap_channel
         label_text: 'Channel'
-        height: dp(160)
     SettingsView:
         id: ap_encryption
         label_text: 'Encryption'
-        size_hint_y: 0.5
 ''')
 
 

--- a/autosportlabs/racecapture/views/util/alertview.py
+++ b/autosportlabs/racecapture/views/util/alertview.py
@@ -7,6 +7,8 @@ from kivy.metrics import dp
 from kivy.app import Builder
 from kivy.properties import StringProperty, ObjectProperty
 from kivy.clock import Clock
+from kivy.metrics import sp
+from kivy.metrics import dp
 from iconbutton import IconButton
 
 __all__ = ('alertPopup, confirmPopup, okPopup, editor_popup')
@@ -49,6 +51,7 @@ Builder.load_string('''
     BoxLayout:
         id: content
     GridLayout:
+        id: buttons
         cols: 2
         size_hint_y: None
         height: '44sp'
@@ -96,7 +99,8 @@ def editor_popup(title, content, answerCallback):
     popup = Popup(title=title,
                     content=content,
                     size_hint=(0.7, 0.8),
-                    auto_dismiss= False)
+                    auto_dismiss= False,
+                  title_size=sp(18))
     popup.open()
     return popup
     

--- a/autosportlabs/uix/bettertextinput.py
+++ b/autosportlabs/uix/bettertextinput.py
@@ -12,7 +12,7 @@ class BetterTextInput(ValueField):
 
     def __init__(self, max_chars=200000, regex=None, **kwargs):
         super(BetterTextInput, self).__init__(**kwargs)
-        self.font_size = self.height * 0.30
+        self.font_size = self.height * 0.20
         self.max_chars = max_chars
         self.regex = regex
 

--- a/settingsview.kv
+++ b/settingsview.kv
@@ -1,6 +1,8 @@
 #:kivy 1.9.1
 
 <SettingsView>:
+    size_hint_y: None
+    height: max(root.ids.helplabel.texture_size[1],sp(30)) + root.ids.fieldlabel.texture_size[1]
     BoxLayout:
         rcid: 'fieldContainer'
         orientation: 'vertical'
@@ -10,6 +12,7 @@
             FieldLabel:
                 size_hint: (0.65, 1.0)
                 rcid: 'fieldLabel'
+                id: fieldlabel
                 halign: 'right'
                 font_size: sp(24)
                 text: ''
@@ -20,6 +23,7 @@
                     rcid: 'control'
                     id: control
         TextWidget:
+            id: helplabel
             rcid: 'helpLabel'
             halign: 'right'
             text: ''


### PR DESCRIPTION
Yeah.... so I shot myself in the foot when I messed with some layouts in 1.6.0 and 1.7.0 at the same time. This fixes problems with the BluetoothConfigView and SettingsView, along with fixing spinner heights in the Wireless settings view.