### PR TITLE
Fixed issue when exceptions not being logged properly within the api code.

### DIFF
--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -130,8 +130,8 @@ class RcpApi:
         try:
             self.comms.close()
             self.comms.device = None
-        except Exception:
-            Logger.warn('RCPAPI: Message rx worker exception: {} | {}'.format(msg, str(Exception)))
+        except Exception as e:
+            Logger.warn('RCPAPI: Message rx worker exception during comms shutdown: {}'.format(str(e)))
             Logger.info(traceback.format_exc())
 
     def detect_win(self, version_info):
@@ -192,8 +192,8 @@ class RcpApi:
                 Logger.debug("RCPAPI: Port not open...")
                 msg = ''
                 sleep(1.0)
-            except Exception:
-                Logger.warn('RCPAPI: Message rx worker exception: {} | {}'.format(msg, str(Exception)))
+            except Exception as e:
+                Logger.warn('RCPAPI: Message rx worker exception: {} | {}'.format(repr(msg), str(e)))
                 Logger.debug(traceback.format_exc())
                 msg = ''
                 error_count += 1


### PR DESCRIPTION
While testing a TCP based log replay server I came across a few cases where a message from the server would fail to parse but the RaceCapture app didn't produce useful output about the exception.  The reason for adding the repr() call around the msg is to output non-printable characters in a way that it can be determined in the logs what the app saw.