### PR TITLE
Change Logger.info() to debug() for comms and RCAPI info

### DIFF
--- a/autosportlabs/comms/comms.py
+++ b/autosportlabs/comms/comms.py
@@ -66,7 +66,7 @@ def connection_message_process(connection, device, rx_queue, tx_queue, command_q
                     Logger.debug('Comms: connection process: got close command')
                     reader_writer_should_run.clear()
             except Empty:
-                Logger.info('Comms: keep alive timeout')
+                Logger.debug('Comms: keep alive timeout')
                 reader_writer_should_run.clear()
         Logger.debug('Comms: connection worker exiting')
 
@@ -76,9 +76,10 @@ def connection_message_process(connection, device, rx_queue, tx_queue, command_q
         try:
             connection.close()
         except:
-            Logger.error('Comms: Exception closing connection worker connection')
+            Logger.debug('Comms: Exception closing connection worker connection')
+            Logger.debug(traceback.format_exc())
     except Exception as e:
-        Logger.error('Comms: Exception setting up connection process: ' + str(type(e)) + str(e))
+        Logger.debug('Comms: Exception setting up connection process: ' + str(type(e)) + str(e))
         Logger.debug(traceback.format_exc())
 
     Logger.debug('Comms: connection worker exited')
@@ -120,7 +121,7 @@ class Comms():
 
     def open(self):
         connection = self._connection
-        Logger.info('Comms: Opening connection ' + str(self.device))
+        Logger.debug('Comms: Opening connection ' + str(self.device))
         self.start_connection_process()
 
     def keep_alive(self):

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -99,7 +99,7 @@ class RcpApi:
         self._msg_rx_thread = t
 
     def _shutdown_workers(self):
-        Logger.info('RCPAPI: Stopping msg rx worker')
+        Logger.debug('RCPAPI: Stopping msg rx worker')
         self._running.clear()
         # this allows the auto detect worker to fall through if needed
         self._auto_detect_event.set()
@@ -126,13 +126,13 @@ class RcpApi:
         self.shutdown_comms()
 
     def shutdown_comms(self):
-        Logger.info('RCPAPI: shutting down comms')
+        Logger.debug('RCPAPI: shutting down comms')
         try:
             self.comms.close()
             self.comms.device = None
         except Exception:
             Logger.warn('RCPAPI: Message rx worker exception: {} | {}'.format(msg, str(Exception)))
-            Logger.info(traceback.format_exc())
+            Logger.debug(traceback.format_exc())
 
     def detect_win(self, version_info):
         self.level_2_retries = DEFAULT_LEVEL2_RETRIES
@@ -698,7 +698,7 @@ class RcpApi:
                                 break  # we found something!
                         else:
                             try:
-                                Logger.info('RCPAPI: Giving up on ' + str(device))
+                                Logger.debug('RCPAPI: Giving up on ' + str(device))
                                 comms.close()
                             finally:
                                 pass
@@ -712,7 +712,7 @@ class RcpApi:
                             pass
 
                 if version_result.version_json != None:
-                    Logger.info("RCPAPI: Found device version " + str(testVer) + " on port: " + str(comms.device))
+                    Logger.debug("RCPAPI: Found device version " + str(testVer) + " on port: " + str(comms.device))
                     self.detect_win(testVer)
                     self._auto_detect_event.clear()
                     self._settings.userPrefs.set_pref('preferences', 'last_known_device', comms.device)
@@ -731,4 +731,4 @@ class RcpApi:
                 self.sendCommandLock.release()
                 sleep(AUTODETECT_COOLOFF_TIME)
 
-        Logger.info('RCPAPI: auto_detect_worker exiting')
+        Logger.debug('RCPAPI: auto_detect_worker exiting')

--- a/autosportlabs/racecapture/status/statuspump.py
+++ b/autosportlabs/racecapture/status/statuspump.py
@@ -43,10 +43,11 @@ class StatusPump(object):
 
     def stop(self):
         self._running.clear()
-        try:
-            self._status_thread.join()
-        except Exception as e:
-            Logger.warn('StatusPump: failed to join status_worker: {}'.format(e))
+        if self._status_thread:
+            try:
+                self._status_thread.join()
+            except Exception as e:
+                Logger.warn('StatusPump: failed to join status_worker: {}'.format(e))
 
     def status_worker(self):
         Logger.info('StatusPump: status_worker starting')


### PR DESCRIPTION
Currently the comms and RCAPI classes are a bit chatty via Logger.info() calls, which makes it hard to debug and develop because they spam the console. This changes their calls debug(). Most of the info() calls were the same information as shown in the status bar in the app, so not much is lost during normal development.