### PR TITLE
Double the time we wait for the version message

### DIFF
--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -771,7 +771,7 @@ class RcpApi:
                         comms.device = device
                         comms.open()
                         self.sendGetVersion()
-                        version_result_event.wait(1)
+                        version_result_event.wait(2)
                         version_result_event.clear()
                         if version_result.version_json != None:
                             testVer.fromJson(version_result.version_json.get('ver', None))


### PR DESCRIPTION
Waiting 1 second doesn't seem to be enough when it comes to reading
the version information that gets returned from the RCT device.
This was preventing us from reconnecting reliably.  Bumping this to
two seconds made it much more reliable.

Issue #1122