### PR TITLE
default to all geo regions

### DIFF
--- a/resource/settings/geo_regions.json
+++ b/resource/settings/geo_regions.json
@@ -1,6 +1,10 @@
 {
     "regions": [
         {
+        "name": "All",
+        "points": []
+        },
+        {
             "name": "USA West",
             "points": [
                 [
@@ -329,10 +333,6 @@
                     -86.980894
                 ]
             ]
-        },
-        {
-            "name": "All",
-            "points": []
-        }                     
+        }
     ]
 }


### PR DESCRIPTION
Have the track selection widget default to all geo regions instead of west coast. b/c polite.