### PR TITLE
Validate ip address when opening connection

### DIFF
--- a/autosportlabs/comms/socket/socketcomm.py
+++ b/autosportlabs/comms/socket/socketcomm.py
@@ -34,7 +34,7 @@ class SocketComm(object):
     Responsible for communicating with a socket connection to a RC device
      Starts up threads for reading/writing data and pushes/reads data to queues
     """
-    CONNECT_TIMEOUT = 1.0
+    CONNECT_TIMEOUT = 2.0
     DEFAULT_TIMEOUT = 1.0
     QUEUE_FULL_TIMEOUT = 1.0
     TX_QUEUE_SIZE = 5

--- a/autosportlabs/comms/socket/socketcomm.py
+++ b/autosportlabs/comms/socket/socketcomm.py
@@ -34,7 +34,7 @@ class SocketComm(object):
     Responsible for communicating with a socket connection to a RC device
      Starts up threads for reading/writing data and pushes/reads data to queues
     """
-    CONNECT_TIMEOUT = 2.0
+    CONNECT_TIMEOUT = 1.0
     DEFAULT_TIMEOUT = 1.0
     QUEUE_FULL_TIMEOUT = 1.0
     TX_QUEUE_SIZE = 5

--- a/autosportlabs/comms/socket/socketconnection.py
+++ b/autosportlabs/comms/socket/socketconnection.py
@@ -23,8 +23,13 @@ import socket
 import json
 
 PORT = 7223
-READ_TIMEOUT = 1
+READ_TIMEOUT = 2
 SCAN_TIMEOUT = 3
+
+class InvalidAddressException(Exception):
+
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
 
 
 class SocketConnection(object):
@@ -74,6 +79,13 @@ class SocketConnection(object):
         :param address: IP address to connect to
         :return: None
         """
+        # Check if we've been given a valid IP
+
+        try:
+            socket.inet_aton(address)
+        except socket.error:
+            raise InvalidAddressException("{} is not a valid IP address".format(address))
+
         # Connect to ip address here
         rc_address = (address, 7223)
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/autosportlabs/comms/socket/socketconnection.py
+++ b/autosportlabs/comms/socket/socketconnection.py
@@ -23,7 +23,7 @@ import socket
 import json
 
 PORT = 7223
-READ_TIMEOUT = 2
+READ_TIMEOUT = 1
 SCAN_TIMEOUT = 3
 
 class InvalidAddressException(Exception):


### PR DESCRIPTION
STR:

* Open app, connect to RCT or RCP with wifi via USB
* Turn on WiFi module, enable AP mode
* Close app
* Connect to AP with your computer
* Run app with `--conn_type=wifi` cli arg
* Watch as the app tries to connect to something in `/dev/`, and it will hang for a while, then (usually) never connect to RC
* Eventually it will throw an exception after ~10s

This happens because the app uses the last connection when trying to connect again to RC, but `/dev/foo` is not a valid IP. For some reason the Python socket lib takes ages to throw an error, so autodetection appears to fail. To fix it, validate IP addresses before connecting and throw an error if it isn't valid.