### PR TITLE
Delimit all commands with \r\n instead of \r

### DIFF
--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -68,6 +68,7 @@ class RcpApi:
     _auto_detect_busy = Event()
 
     COMMAND_SEQUENCE_TIMEOUT = 1.0
+    COMMAND_DELIMETER = "\r\n"
 
     def __init__(self, settings, on_disconnect=None, on_connect=None, **kwargs):
         self.comms = kwargs.get('comms', self.comms)
@@ -372,7 +373,8 @@ class RcpApi:
 
             comms = self.comms
 
-            cmdStr = json.dumps(cmd, separators=(',', ':')) + '\r'
+            cmdStr = json.dumps(cmd, separators=(',', ':')) + \
+                                                 self.COMMAND_DELIMETER
 
             if "s" in cmd:
                 Logger.trace('RCPAPI: Tx: ' + cmdStr)
@@ -836,4 +838,3 @@ class RcpApi:
 
         safe_thread_exit()
         Logger.debug('RCPAPI: auto_detect_worker exiting')
-


### PR DESCRIPTION
This is becasue we treat all commands as serial line commands.  Thus
we should use proper serial line delimeters to delimit the end of a
command.

As an added bonus this helps us work around a shortcoming in the ESP8266
chip (IPD doesn't terminate lines with \r\n).  This allows our serial
library to always read and handle the line appropriately.