### PR TITLE
Fix key error when reading analog config more than once, fix indentation for setAccordionItemTitle

### DIFF
--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -176,9 +176,16 @@ class AnalogConfig(object):
         return {'analogCfg':analogCfgJson}
 
     def build_channels(self):
-        self.channels = []
-        for i in range (self.channelCount):
-            self.channels.append(AnalogChannel())
+        initialized_channel_count = len(self.channels)
+        required_channel_count = self.channelCount
+
+        if initialized_channel_count == required_channel_count:
+            return
+        else:
+            # Probably got a new capabilities, make a new channels array
+            self.channels = []
+            for i in range(required_channel_count):
+                self.channels.append(AnalogChannel())
 
     @property
     def stale(self):

--- a/autosportlabs/racecapture/views/configuration/baseconfigview.py
+++ b/autosportlabs/racecapture/views/configuration/baseconfigview.py
@@ -130,10 +130,10 @@ class BaseMultiChannelConfigView(BaseConfigView):
         super(BaseMultiChannelConfigView, self).on_modified(self, instance, channel_config)
 
     def setAccordionItemTitle(self, accordion, channel_configs, config):
-            i = channel_configs.index(config)
-            accordion_children = accordion.children
-            accordion_item = accordion_children[len(accordion_children) - i - 1]
-            accordion_item.title = self.createTitleForChannel(config)
+        i = channel_configs.index(config)
+        accordion_children = accordion.children
+        accordion_item = accordion_children[len(accordion_children) - i - 1]
+        accordion_item.title = self.createTitleForChannel(config)
         
     def createTitleForChannel(self, channel_config):
         try:


### PR DESCRIPTION
Fixes #1106 ValueError: <autosportlabs.racecapture.config.rcpconfig.AnalogChannel object at 0x7fa2b7c76790> is not in list