### PR TITLE
Don't save links configuration that is generated from flags. Instead save flags.

### DIFF
--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -1204,7 +1204,7 @@ class Capabilities(object):
             "channels": self.channels.to_json_dict(),
             "db": self.storage.to_json_dict(),
             "sampleRates": self.sample_rates.to_json_dict(),
-            "links": self.links.to_json_dict()
+            "flags": self.flags
         }
 
 


### PR DESCRIPTION
Fixes #1167 . We don't need to save the links configuration because it is actually generated by the flags 'config' from RC/RCP. 