### PR TITLE
Save wifi cfg

### DIFF
--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -905,7 +905,6 @@ class TelemetryConfig(object):
 
 class WifiConfig(object):
 
-
     def __init__(self):
         self.active = False
 
@@ -1354,6 +1353,7 @@ class RcpConfig(object):
                              'canCfg':self.canConfig.toJson().get('canCfg'),
                              'obd2Cfg':self.obd2Config.toJson().get('obd2Cfg'),
                              'connCfg':self.connectivityConfig.toJson().get('connCfg'),
+                             'wifiCfg': self.wifi_config.to_json(),
                              'trackCfg':self.trackConfig.toJson().get('trackCfg'),
                              'scriptCfg':self.scriptConfig.toJson().get('scriptCfg'),
                              'trackDb': self.trackDb.toJson().get('trackDb')

--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -1204,7 +1204,7 @@ class Capabilities(object):
             "channels": self.channels.to_json_dict(),
             "db": self.storage.to_json_dict(),
             "sampleRates": self.sample_rates.to_json_dict(),
-            "links": self.links.to_json_dict()
+            "flags": self.flags
         }
 
 


### PR DESCRIPTION
Branched from `no-links-config-save`, PR: https://github.com/autosportlabs/RaceCapture_App/pull/1168, which should be reviewed and merged first in order for this PR to work.