### PR TITLE
Reread accel config after calibration

### DIFF
--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -567,8 +567,11 @@ class RcpApi:
     def setAnalogCfg(self, analogCfg, channelId):
         self.sendSet('setAnalogCfg', analogCfg, channelId)
 
-    def getImuCfg(self, channelId=None):
-        self.sendGet('getImuCfg', channelId)
+    def getImuCfg(self, channelId=None, success_cb=None, fail_cb=None):
+        if success_cb:
+            self.executeSingle(RcpCmd('imuCfg', self.getImuCfg), success_cb, fail_cb)
+        else:
+            self.sendGet('getImuCfg', channelId)
 
     def setImuCfg(self, imuCfg, channelId):
         self.sendSet('setImuCfg', imuCfg, channelId)


### PR DESCRIPTION
After calibration, we need to re-read the configuration so the app has the latest values. Added some state to prevent the app thinking the configuration had changed when we had actually just updated from RC's configuration.