### PR TITLE
make serial comms error quieter in log

### DIFF
--- a/autosportlabs/comms/comms.py
+++ b/autosportlabs/comms/comms.py
@@ -80,6 +80,7 @@ def connection_message_process(connection, device, rx_queue, tx_queue, command_q
             Logger.debug(traceback.format_exc())
     except Exception as e:
         Logger.debug('Comms: Exception setting up connection process: ' + str(type(e)) + str(e))
+        Logger.trace(traceback.format_exc())
 
     Logger.debug('Comms: connection worker exited')
 

--- a/autosportlabs/comms/comms.py
+++ b/autosportlabs/comms/comms.py
@@ -80,7 +80,6 @@ def connection_message_process(connection, device, rx_queue, tx_queue, command_q
             Logger.debug(traceback.format_exc())
     except Exception as e:
         Logger.debug('Comms: Exception setting up connection process: ' + str(type(e)) + str(e))
-        Logger.debug(traceback.format_exc())
 
     Logger.debug('Comms: connection worker exited')
 


### PR DESCRIPTION
Addresses #1149.   exceptions, especially serial exceptions are common, especially when the available list of port changes, no need  to print stack trace.