### PR TITLE
P/brent/analysis defaults

### DIFF
--- a/autosportlabs/racecapture/views/analysis/addstreamview.py
+++ b/autosportlabs/racecapture/views/analysis/addstreamview.py
@@ -173,11 +173,11 @@ class SessionImportView(BaseStreamConnectView):
         self.datastore.delete_session(list_item.session.session_id)
         self.ids.session_list.remove_widget(list_item)
         self.dispatch('on_delete', list_item.session)
-        toast("Session deleted")
+        toast("Session deleted", center_on=self)
 
     def add_session(self, list_item):
         self.dispatch('on_add', list_item.session)
-        toast("Session loaded")
+        toast("Session loaded", center_on=self)
 
     def close(self, *args):
         self.dispatch('on_close')

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -216,7 +216,8 @@ class AnalysisView(Screen):
                 sessions_view.select_lap(new_session_id, best_lap_id, True)
                 HelpInfo.help_popup('suggested_lap', main_chart, arrow_pos='left_mid')
             else:
-                Logger.warn('AnalysisView: Could not determine best lap for session {}'.format(new_session_id))
+                Logger.info('AnalysisView: No best lap could be determined; selecting first lap by default for session {}'.format(new_session_id))
+                sessions_view.select_lap(new_session_id, 0, True)
 
     def on_stream_connecting(self, *args):
         self.stream_connecting = True
@@ -242,6 +243,7 @@ class AnalysisView(Screen):
         Logger.info("AnalysisView: on_add_session: {}".format(session))
         self.check_load_suggested_lap(session.session_id)
         self.ids.sessions_view.append_session(session)
+        self.check_load_suggested_lap(session.session_id)        
 
     def on_delete_session(self, instance, session):
         self.ids.sessions_view.session_deleted(session)

--- a/autosportlabs/racecapture/views/analysis/linechart.py
+++ b/autosportlabs/racecapture/views/analysis/linechart.py
@@ -139,10 +139,8 @@ class LineChart(ChannelAnalysisWidget):
     def on_toggle_chart_mode(self, *args):
         if self.line_chart_mode == LineChartMode.DISTANCE:
             self.line_chart_mode = LineChartMode.TIME
-            toast('Time')
         else:
             self.line_chart_mode = LineChartMode.DISTANCE
-            toast('Distance')
 
         self._redraw_plots()
         self._refresh_chart_mode_toggle()
@@ -426,14 +424,23 @@ class LineChart(ChannelAnalysisWidget):
         finally:
             ProgressSpinner.decrement_refcount()
 
+    def _results_has_distance(self, results):
+        values = results['Distance'].values
+        return len(values) > 0 and values[-1] > 0
+        
     def _add_unselected_channels(self, channels, source_ref):
         ProgressSpinner.increment_refcount()
         def get_results(results):
+            if not self._results_has_distance(results):
+                self.line_chart_mode = LineChartMode.TIME
+                self._refresh_chart_mode_toggle()
             # clone the incoming list of channels and pass it to the handler
-            if self.line_chart_mode == LineChartMode.DISTANCE:
-                Clock.schedule_once(lambda dt: self._add_channels_results_distance(channels[:], results))
-            elif self.line_chart_mode == LineChartMode.TIME:
+            if self.line_chart_mode == LineChartMode.TIME: 
                 Clock.schedule_once(lambda dt: self._add_channels_results_time(channels[:], results))
+                toast('Time')
+            elif self.line_chart_mode == LineChartMode.DISTANCE:
+                Clock.schedule_once(lambda dt: self._add_channels_results_distance(channels[:], results))
+                toast('Distance')
             else:
                 Logger.error('LineChart: Unknown line chart mode ' + str(self.line_chart_mode))
 

--- a/autosportlabs/uix/toast/kivytoast.py
+++ b/autosportlabs/uix/toast/kivytoast.py
@@ -33,10 +33,9 @@ TOAST_KV='''
 
 '''
 
-Builder.load_string(TOAST_KV)
-
 class _Toast(Label):
     _transparency = NumericProperty(1.0)
+    Builder.load_string(TOAST_KV)
 
     def __init__(self, text, *args, **kwargs):
         '''Show the toast in the main window.  The attatch_to logic from 
@@ -44,6 +43,7 @@ class _Toast(Label):
         does need to go on top of everything.
         '''
         self._bound = False
+        self._center_on = kwargs.get('center_on')
         super(_Toast, self).__init__(text=text, *args, **kwargs)
     
     def show(self, length_long, *largs):
@@ -67,7 +67,10 @@ class _Toast(Label):
             
     def _align(self, win, size):
         self.x = (size[0] - self.width) / 2.0
-        self.y = size[1] * 0.1
+        if self._center_on:
+            self.y = self._center_on.y + self._center_on.size[1] * 0.1
+        else:
+            self.y = size[1] * 0.1
 
     def _in_out(self, dt):
         self._duration -= dt * 1000
@@ -77,5 +80,14 @@ class _Toast(Label):
             Window.remove_widget(self)
             return False
 
-def toast(text, length_long=False):
-    _Toast(text=text).show(length_long)
+def toast(text, length_long=False, center_on=None):
+    """Display a short message on the screen that will automatically dismiss
+    :param text the text to display
+    :type text String
+    :param length_long True if the display should persist longer
+    :type length_long bool
+    :param center_on The widget to center on. if not specified, centers on the window
+    :type center_on Widget
+    :return None
+    """
+    _Toast(text=text, center_on=center_on).show(length_long)


### PR DESCRIPTION
Usability improvement that lets the user immediately see useful data when they first import a session, and automatically constraints to time if the distance never incremented in a lap (e.g. a static test, or when data is gathered with no GPS). 

Enhance Toast widget so it can be centered on a widget; helps prevent overlapping Toast messages in this case (line chart and session import view).

 Resolves #1222 
