### PR TITLE
Fix crash when datastore has session/lap with inadequate data

### DIFF
--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -996,7 +996,11 @@ class DataStore(object):
                                 GROUP BY LapCount, session_id
                                 ORDER BY datapoint.LapCount ASC;''',
                                 (session_id,)):
-            laps.append(Lap(session_id=row[0], lap=row[1] - 1, lap_time=row[2]))
+
+            # It's possible a lap has no lap count
+            lap = row[1] - 1 if row[1] else None
+
+            laps.append(Lap(session_id=row[0], lap=lap, lap_time=row[2]))
 
         # Figure out if there are samples beyond the last lap
         extra_lap_query = '''SELECT COUNT(*) FROM sample JOIN datapoint ON datapoint.sample_id=sample.id
@@ -1008,7 +1012,8 @@ class DataStore(object):
             c = self._conn.cursor()
 
             for row in c.execute(extra_lap_query, [session_id, laps[-1].lap]):
-                laps.append(Lap(session_id=session_id, lap=(laps[-1].lap + 1), lap_time=None))
+                lap_number = laps[-1].lap + 1 if laps[-1].lap else ''
+                laps.append(Lap(session_id=session_id, lap=lap_number, lap_time=None))
                 break
         
         #Filter so we only include valid laps

--- a/autosportlabs/racecapture/views/analysis/channelvaluesview.py
+++ b/autosportlabs/racecapture/views/analysis/channelvaluesview.py
@@ -56,7 +56,7 @@ class ChannelValueView(BoxLayout):
 
     @lap.setter
     def lap(self, value):
-        self.lap_view.text = str(int(value))
+        self.lap_view.text = str(value)
 
     @property
     def channel(self):

--- a/autosportlabs/racecapture/views/analysis/markerevent.py
+++ b/autosportlabs/racecapture/views/analysis/markerevent.py
@@ -24,7 +24,7 @@ class SourceRef(object):
     lap = 0
     session = 0
     def __init__(self, lap, session):
-        self.lap = int(lap)
+        self.lap = int(lap) if lap else ''
         self.session = (session)
    
     def __str__(self):

--- a/autosportlabs/racecapture/views/analysis/sessionlistview.py
+++ b/autosportlabs/racecapture/views/analysis/sessionlistview.py
@@ -79,7 +79,8 @@ class Session(BoxLayout):
         return len(self.ids.lap_list.children)
 
     def append_lap(self, session, lap, laptime):
-        text = '{} :: {}'.format(int(lap), format_laptime(laptime))
+        lap_number = int(lap) if isinstance( lap, (int)) else ''
+        text = '{} :: {}'.format(lap_number, format_laptime(laptime))
         lapitem = LapItemButton(session=session, text=text, lap=lap, laptime=laptime)
         self.ids.lap_list.add_widget(lapitem)
         return lapitem


### PR DESCRIPTION
It's not pretty, but it works. I'm not sure how else to handle the data other than just ignoring data like this completely?