### PR TITLE
P/brent/lap data broken

### DIFF
--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -996,7 +996,9 @@ class DataStore(object):
                                 GROUP BY LapCount, session_id
                                 ORDER BY datapoint.LapCount ASC;''',
                                 (session_id,)):
-            laps.append(Lap(session_id=row[0], lap=row[1] - 1, lap_time=row[2]))
+            lap = row[1]
+            lap = 0 if lap is None else lap
+            laps.append(Lap(session_id=row[0], lap=lap - 1, lap_time=row[2]))
 
         # Figure out if there are samples beyond the last lap
         extra_lap_query = '''SELECT COUNT(*) FROM sample JOIN datapoint ON datapoint.sample_id=sample.id
@@ -1010,8 +1012,8 @@ class DataStore(object):
             for row in c.execute(extra_lap_query, [session_id, laps[-1].lap]):
                 laps.append(Lap(session_id=session_id, lap=(laps[-1].lap + 1), lap_time=None))
                 break
-        
-        #Filter so we only include valid laps
+
+        # Filter so we only include valid laps
         laps = [lap for lap in laps if lap.lap >= 0]
         return laps
 

--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -996,11 +996,7 @@ class DataStore(object):
                                 GROUP BY LapCount, session_id
                                 ORDER BY datapoint.LapCount ASC;''',
                                 (session_id,)):
-
-            # It's possible a lap has no lap count
-            lap = row[1] - 1 if row[1] else None
-
-            laps.append(Lap(session_id=row[0], lap=lap, lap_time=row[2]))
+            laps.append(Lap(session_id=row[0], lap=row[1] - 1, lap_time=row[2]))
 
         # Figure out if there are samples beyond the last lap
         extra_lap_query = '''SELECT COUNT(*) FROM sample JOIN datapoint ON datapoint.sample_id=sample.id
@@ -1012,8 +1008,7 @@ class DataStore(object):
             c = self._conn.cursor()
 
             for row in c.execute(extra_lap_query, [session_id, laps[-1].lap]):
-                lap_number = laps[-1].lap + 1 if laps[-1].lap else ''
-                laps.append(Lap(session_id=session_id, lap=lap_number, lap_time=None))
+                laps.append(Lap(session_id=session_id, lap=(laps[-1].lap + 1), lap_time=None))
                 break
         
         #Filter so we only include valid laps

--- a/autosportlabs/racecapture/views/analysis/channelvaluesview.py
+++ b/autosportlabs/racecapture/views/analysis/channelvaluesview.py
@@ -56,7 +56,7 @@ class ChannelValueView(BoxLayout):
 
     @lap.setter
     def lap(self, value):
-        self.lap_view.text = str(value)
+        self.lap_view.text = str(int(value))
 
     @property
     def channel(self):

--- a/autosportlabs/racecapture/views/analysis/markerevent.py
+++ b/autosportlabs/racecapture/views/analysis/markerevent.py
@@ -24,7 +24,7 @@ class SourceRef(object):
     lap = 0
     session = 0
     def __init__(self, lap, session):
-        self.lap = int(lap) if lap else ''
+        self.lap = int(lap)
         self.session = (session)
    
     def __str__(self):

--- a/autosportlabs/racecapture/views/analysis/sessionlistview.py
+++ b/autosportlabs/racecapture/views/analysis/sessionlistview.py
@@ -79,11 +79,7 @@ class Session(BoxLayout):
         return len(self.ids.lap_list.children)
 
     def append_lap(self, session, lap, laptime):
-        try:
-            lap_number = int(lap)
-        except ValueError:
-            lap_number = ''
-        text = '{} :: {}'.format(lap_number, format_laptime(laptime))
+        text = '{} :: {}'.format(int(lap), format_laptime(laptime))
         lapitem = LapItemButton(session=session, text=text, lap=lap, laptime=laptime)
         self.ids.lap_list.add_widget(lapitem)
         return lapitem


### PR DESCRIPTION
I did a poor job reviewing #1236 and jumped the gun approving it. 

The original problem in #1230 is really limited to cases where a single session was recorded - like static testing with no laps.  

Using spaces for lap IDs was causing heartburn for other parts of the analysis view. The proposed change in this PR makes the lap '0'  so the rest of the analysis views work as expected. This is safe since only one session or 'lap' would be generated for this type of session recording, anyway.

The original changeset was revered and an addition was made to datastore.py, noted below. 

@ryandoherty  sorry for my sloppy review.