### PR TITLE
Fix disconnect when socket command queue is empty

### DIFF
--- a/autosportlabs/comms/socket/socketcomm.py
+++ b/autosportlabs/comms/socket/socketcomm.py
@@ -231,7 +231,6 @@ class SocketComm(object):
                         reader_writer_should_run.clear()
                 except Empty:
                     Logger.debug('SocketComm: keep alive timeout')
-                    reader_writer_should_run.clear()
             Logger.debug('SocketComm: connection worker exiting')
 
             reader_thread.join()


### PR DESCRIPTION
So this is a bug or copy/pasta typo where the command thread for the socket connection disconnects if no messages are in the command queue. It should just keep running if no messages are there, not disconnect. Seems to fix #1210 