### PR TITLE
Issue #1077: Hide Firware update menu item when using wifi.

### DIFF
--- a/autosportlabs/comms/androidcomms.py
+++ b/autosportlabs/comms/androidcomms.py
@@ -58,3 +58,9 @@ class AndroidComms(object):
     def write_message(self, message):
         if not self._bt_conn.write(message):
             raise CommsErrorException()
+
+    def is_wireless(self):
+        """Returns if this comms object uses wireless communications or not.
+        :return: True
+        """
+        return True

--- a/autosportlabs/comms/comms.py
+++ b/autosportlabs/comms/comms.py
@@ -152,3 +152,9 @@ class Comms():
     def write_message(self, message):
         if not self.isOpen(): raise PortNotOpenException('Port Closed')
         self._tx_queue.put(message, True, Comms.QUEUE_FULL_TIMEOUT)
+
+    def is_wireless(self):
+        """Returns if this comms object uses wireless communications or not.
+        :return: False
+        """
+        return False

--- a/autosportlabs/comms/socket/socketcomm.py
+++ b/autosportlabs/comms/socket/socketcomm.py
@@ -137,6 +137,12 @@ class SocketComm(object):
         if not self.isOpen(): raise PortNotOpenException('Port Closed')
         self._tx_queue.put(message, True, SocketComm.QUEUE_FULL_TIMEOUT)
 
+    def is_wireless(self):
+        """Returns if this comms object uses wireless communications or not.
+        :return: True
+        """
+        return True
+
     def _connection_thread_message_reader(self, rx_queue, connection, should_run):
         """This method is designed to be run in a thread, it will loop infinitely as long as should_run.is_set()
         returns True. In its loop it will attempt to read data from the socket connection

--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -758,6 +758,9 @@ class RcpApi:
         else:
             self.sendCommand({'s':0})
 
+    def is_firmware_update_supported(self):
+        return self.comms and not self.comms.is_wireless()
+
     def start_auto_detect_worker(self):
         self._auto_detect_event.clear()
         t = Thread(target=self.auto_detect_worker)

--- a/autosportlabs/racecapture/views/configuration/rcp/configview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/configview.py
@@ -12,8 +12,6 @@ from kivy.clock import Clock
 from kivy import platform
 from kivy.logger import Logger
 
-FIRMWARE_UPDATABLE = not (platform == 'android' or platform == 'ios')
-
 from autosportlabs.racecapture.views.configuration.rcp.analogchannelsview import *
 from autosportlabs.racecapture.views.configuration.rcp.imuchannelsview import *
 from autosportlabs.racecapture.views.configuration.rcp.gpschannelsview import *
@@ -27,8 +25,7 @@ from autosportlabs.racecapture.views.configuration.rcp.canconfigview import *
 from autosportlabs.racecapture.views.configuration.rcp.telemetry.telemetryconfigview import *
 from autosportlabs.racecapture.views.configuration.rcp.wirelessconfigview import *
 from autosportlabs.racecapture.views.configuration.rcp.scriptview import *
-if FIRMWARE_UPDATABLE:
-    from autosportlabs.racecapture.views.configuration.rcp.firmwareupdateview import *
+from autosportlabs.racecapture.views.configuration.rcp.firmwareupdateview import *
 from autosportlabs.racecapture.views.file.loaddialogview import LoadDialog
 from autosportlabs.racecapture.views.file.savedialogview import SaveDialog
 from autosportlabs.racecapture.views.util.alertview import alertPopup, confirmPopup
@@ -206,7 +203,7 @@ class ConfigView(Screen):
             node_name = 'Logs'
         attach_node(node_name, None, lambda: create_scripting_view(self.rc_config.capabilities))
 
-        if FIRMWARE_UPDATABLE:
+        if self.rc_api.is_firmware_update_supported():
             attach_node('Firmware', None, lambda: FirmwareUpdateView(rc_api=self.rc_api, settings=self._settings))
 
         self.ids.menu.select_node(default_node)

--- a/test/autosportlabs/racecapture/api/__init__.py
+++ b/test/autosportlabs/racecapture/api/__init__.py
@@ -1,0 +1,19 @@
+#
+# Race Capture App
+#
+# Copyright (C) 2014-2016 Autosport Labs
+#
+# This file is part of the Race Capture App
+#
+# This is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See the GNU General Public License for more details. You should
+# have received a copy of the GNU General Public License along with
+# this code. If not, see <http://www.gnu.org/licenses/>.

--- a/test/autosportlabs/racecapture/api/test_rcpapi.py
+++ b/test/autosportlabs/racecapture/api/test_rcpapi.py
@@ -1,0 +1,49 @@
+#
+# Race Capture App
+#
+# Copyright (C) 2014-2016 Autosport Labs
+#
+# This file is part of the Race Capture App
+#
+# This is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See the GNU General Public License for more details. You should
+# have received a copy of the GNU General Public License along with
+# this code. If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from mock import Mock
+from autosportlabs.racecapture.api.rcpapi import RcpApi
+
+class TestRcpApi(unittest.TestCase):
+    def setUp(self):
+        self.settings = Mock()
+        self.comms = Mock()
+
+    def test_is_firmware_update_available_no_comms(self):
+        rcpapi = RcpApi(settings=self.settings, comms=None)
+        self.assertFalse(rcpapi.is_firmware_update_supported())
+
+    def test_is_firmware_update_available_on_wired(self):
+        self.comms.is_wireless = Mock(return_value=False)
+        rcpapi = RcpApi(settings=self.settings, comms=self.comms)
+        self.assertTrue(rcpapi.is_firmware_update_supported())
+
+    def test_is_firmware_update_available_on_wireless(self):
+        self.comms.is_wireless = Mock(return_value=True)
+        rcpapi = RcpApi(settings=self.settings, comms=self.comms)
+        self.assertFalse(rcpapi.is_firmware_update_supported())
+
+
+def main():
+    unittest.main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This may have to be revisited if the app ever supports switching connection types at runtime but for now it seems to work as intended.