### PR TITLE
Mark RCPAPI worker threads as daemon threads, clean up some deprecated calls.

### DIFF
--- a/autosportlabs/racecapture/api/rcpapi.py
+++ b/autosportlabs/racecapture/api/rcpapi.py
@@ -133,6 +133,7 @@ class RcpApi:
     def _start_message_rx_worker(self):
         self._running.set()
         t = Thread(target=self.msg_rx_worker)
+        t.daemon = True
         t.start()
         self._msg_rx_thread = t
 
@@ -148,6 +149,7 @@ class RcpApi:
 
     def _start_cmd_sequence_worker(self):
         t = Thread(target=self.cmd_sequence_worker)
+        t.daemon = True
         t.start()
         self._cmd_sequence_thread = t
 
@@ -764,6 +766,7 @@ class RcpApi:
     def start_auto_detect_worker(self):
         self._auto_detect_event.clear()
         t = Thread(target=self.auto_detect_worker)
+        t.daemon = True
         t.start()
         self._auto_detect_worker = t
 

--- a/autosportlabs/racecapture/settings/systemsettings.py
+++ b/autosportlabs/racecapture/settings/systemsettings.py
@@ -39,7 +39,7 @@ class SystemSettings(object):
         self.appConfig = AppConfig()
 
     def get_default_data_dir(self):
-        if platform() == 'android':
+        if platform == 'android':
             from jnius import autoclass
             PythonActivity = autoclass('org.renpy.android.PythonActivity')
             activity = PythonActivity.mActivity
@@ -48,7 +48,7 @@ class SystemSettings(object):
             return self.data_dir
 
     def get_default_user_files_dir(self):
-        if platform() == 'android':
+        if platform == 'android':
             from jnius import autoclass
             env = autoclass('android.os.Environment')
             return path.join(env.getExternalStorageDirectory().getPath(), 'racecapture')
@@ -56,7 +56,7 @@ class SystemSettings(object):
             return self.get_default_desktop_config_dir()
 
     def get_default_desktop_config_dir(self):
-        if platform() == 'win':
+        if platform == 'win':
             return path.join(dirname(expanduser('~')), 'Documents')
         else:
             return path.join(expanduser('~'), 'Documents')

--- a/autosportlabs/widgets/filebrowser/__init__.py
+++ b/autosportlabs/widgets/filebrowser/__init__.py
@@ -77,9 +77,8 @@ from os.path import sep, dirname, expanduser, isdir
 from os import walk
 from functools import partial
 from utils import is_mobile_platform
-from autosportlabs.widgets.scrollcontainer import ScrollContainer
 
-platform = core_platform()
+platform = core_platform
 if platform == 'win':
     from ctypes import windll, create_unicode_buffer
 


### PR DESCRIPTION
This PR has two commits, the first just fixes some deprecated call warnings that were showing up in the logs and should have no effect on how the app behaves.

The second commit is to resolve a few issues I've noticed while running the app using Linux on a Raspberry Pi 3.  The issues also present themselves on OSX but are not as big of a deal given that the application isn't fullscreen like it is on Linux.  

There are basically two issues that manifest in the same behavior.  First, if a user tries to kill the app using a SIGINT or CTRL-C then kivy tries to kill the application but the background worker threads keep the application from dying.  Second, if an unhandled exception is thrown in the application there is the appears that the application freezes, however, kivy is trying to close the app, similar to a SIGINT, but stays active due to the worker threads.

By switching the background threads to be daemon threads it allows the kivy app to close if either a SIGINT is received or if an unhandled exception occurs.  