### PR TITLE
Issue #931: Fixed issue with line number not being incremented

### DIFF
--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -615,6 +615,7 @@ class DataStore(object):
 
             # Down to business, first, we stuff each channel's sample
             # into the work list
+            Logger.debug('DataStore: work_list.len={}, channels.len={}, current_line={}'.format(work_list_len, channels_len, current_line))
             for c in range(channels_len):
                 work_list[c].append(channels[c])
 
@@ -643,19 +644,20 @@ class DataStore(object):
                     # the current list in work_list
                     work_list[c] = work_list[c][-1:]
 
-
             # Ok, we now have THINGS in our yield list, if we have
             # something in EVERY column of the yield list, create a
             # new list containing the first item in every column,
             # shift all columns down one, and yield the new list
             if not 0 in [len(x) for x in yield_list]:
-                current_line += 1
                 ds_to_yield = [x[0] for x in yield_list]
                 map(lambda x: x.pop(0), yield_list)
                 if progress_cb:
                     percent_complete = float(current_line) / line_count * 100
                     progress_cb(percent_complete)
                 yield ds_to_yield
+
+            # Increment line number
+            current_line += 1
 
         # now, finish off and extrapolate the remaining items in the
         # work list and extend the yield list with the resultant values


### PR DESCRIPTION
The 'current_line' wasn't being incremented which would allow the code to fail if the second line was malformed.  

I moved the current_line += 1 to the bottom of the loop.  The only effect this would have verses it's previous placement would be on the calculation of the percentage status bar.  It could be considered off by one but given that the dialog disappears at the end of the loading I don't know if would be noticeable by the end user.