### PR TITLE
Update canchannelsview.py

### DIFF
--- a/autosportlabs/racecapture/views/configuration/rcp/canchannelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/canchannelsview.py
@@ -290,7 +290,7 @@ class CANValueMappingTab(CANChannelMappingTab):
     def init_view(self, channel_cfg):
         self._loaded = False
         self.channel_cfg = channel_cfg
-        self.ids.endian.setValueMap({0: 'Big (MSB)', 1: 'Little (LSB)'}, 'Big (MSB)')
+        self.ids.endian.setValueMap({1: 'Big (MSB)', 0: 'Little (LSB)'}, 'Big (MSB)')
         self.update_mapping_spinners()
 
         # CAN offset


### PR DESCRIPTION
Endianess was backwards in the commit, false (0) is little, true (1) is big, the kivy view should represent the same thing.
Tested this with 2.11 with an external can message.