### PR TITLE
P/brent/analysis robusto

### DIFF
--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -116,13 +116,17 @@ def _smooth_dataset(dset, smoothing_rate):
 
 def _scrub_sql_value(value):
     """
-    Takes a string and strips it of all non-alphanumeric characters, making it safe for use in a SQL query for things
-    like a column name or table name. Not to be confused with traditional SQL escaping with backslashes or
+    Takes a string and strips it of all non-alphanumeric characters, and prefixes with a '_' if the name starts with a digit.
+    This makes it safe for use in a SQL query for things like a column name or table name. 
+    Not to be confused with traditional SQL escaping with backslashes or
     parameterized queries
     :param value: String
     :return: String
     """
-    return ''.join([char for char in value if char.isalnum()])
+    sql_name = ''.join([char for char in value if char.isalnum()])
+    if sql_name[:1].isdigit():
+        sql_name = '_' + sql_name
+    return sql_name
 
 
 class DataSet(object):

--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -407,22 +407,40 @@ class DataStore(object):
         tool.engine.dispose()
 
     def _add_extra_indexes(self, channels):
+        existing_indexes = []
+        c = self._conn.cursor()
+        for row in c.execute('PRAGMA index_list(datapoint)'):
+            existing_indexes.append(row[1])
+
         extra_indexes = []
         for c in channels:
-            c = str(c)
-            if c in self.EXTRA_INDEX_CHANNELS:
-                extra_indexes.append(_scrub_sql_value(c))
+            name = c.name
+            if name in self.EXTRA_INDEX_CHANNELS:
+                extra_indexes.append(_scrub_sql_value(name))
 
         for index_channel in extra_indexes:
-            self._conn.execute("""CREATE INDEX {}_index_id on datapoint({})""".format(index_channel, index_channel))
+            index_name = '{}_index_id'.format(index_channel)
+            if index_name in existing_indexes:
+                continue
+            self._conn.execute("""CREATE INDEX {} on datapoint({})""".format(index_name, index_channel))
 
     def _extend_datalog_channels(self, channels):
+        """
+        Add new columns as needed
+        """
+        existing_columns = []
+        c = self._conn.cursor()
+        for row in c.execute('PRAGMA table_info(datapoint)'):
+            existing_columns.append(row[1])
+
         for channel in channels:
+            name = channel.name
+            if name in existing_columns:
+                continue
             # Extend the datapoint table to include the channel as a
             # new field
             self._conn.execute("""ALTER TABLE datapoint
-            ADD {} REAL""".format(_scrub_sql_value(channel.name)))
-
+            ADD {} REAL""".format(_scrub_sql_value(name)))
         self._add_extra_indexes(channels)
         self._conn.commit()
 
@@ -431,14 +449,10 @@ class DataStore(object):
         channels = []
 
         try:
-            new_channels = []
             for i in range(1, len(raw_channels) + 1):
                 name, units, min, max, samplerate = raw_channels[i - 1].replace('"', '').split('|')
                 channel = DatalogChannel(name, units, float(min), float(max), int(samplerate), 0)
                 channels.append(channel)
-                if not name in [x.name for x in self._channels]:
-                    new_channels.append(channel)
-            self._extend_datalog_channels(new_channels)
         except:
             import sys, traceback
             print "Exception in user code:"
@@ -917,6 +931,7 @@ class DataStore(object):
 
         header = dl.readline()
         channels = self._parse_datalog_headers(header)
+        self._extend_datalog_channels(channels)
 
         # Create an event to be tagged to these records
         session_id = self.create_session(name, notes)

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -221,9 +221,10 @@ class AnalysisView(Screen):
     def on_stream_connected(self, instance, new_session_id):
         self.stream_connecting = False
         self._dismiss_popup()
-        session = self._datastore.get_session_by_id(new_session_id)
-        self.ids.sessions_view.append_session(session)
-        self.check_load_suggested_lap(new_session_id)
+        if new_session_id:
+            session = self._datastore.get_session_by_id(new_session_id)
+            self.ids.sessions_view.append_session(session)
+            self.check_load_suggested_lap(new_session_id)
 
     def _set_suggested_channels(self, channels):
         self._settings.userPrefs.set_pref_list('analysis_preferences', 'selected_analysis_channels', channels)

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -153,7 +153,7 @@ class AnalysisView(Screen):
     def on_pre_enter(self, *args):
         # immediately stop any session recording if we're entering analysis view
         self._session_recorder.stop(stop_now=True)
-        
+
     def on_sessions(self, instance, value):
         self.ids.channelvalues.sessions = value
 
@@ -225,15 +225,9 @@ class AnalysisView(Screen):
         self.ids.sessions_view.append_session(session)
         self.check_load_suggested_lap(new_session_id)
 
-    def _get_suggested_channels(self):
-        suggested_channels = self._settings.userPrefs.get_pref_list('analysis_preferences', 'selected_analysis_channels')
-        if len(suggested_channels) == 0:
-            suggested_channels = UserPrefs.DEFAULT_ANALYSIS_CHANNELS
-        return suggested_channels
-        
     def _set_suggested_channels(self, channels):
         self._settings.userPrefs.set_pref_list('analysis_preferences', 'selected_analysis_channels', channels)
-        
+
     # The following selects a best lap if there are no other laps currently selected
     def check_load_suggested_lap(self, new_session_id):
         sessions_view = self.ids.sessions_view
@@ -243,9 +237,6 @@ class AnalysisView(Screen):
             if best_lap_id:
                 Logger.info('AnalysisView: Convenience selected a suggested session {} / lap {}'.format(new_session_id, best_lap_id))
                 main_chart = self.ids.mainchart
-                suggested_channels = self._get_suggested_channels()
-                main_chart.select_channels(suggested_channels)
-                self.ids.channelvalues.select_channels(suggested_channels)
                 sessions_view.select_lap(new_session_id, best_lap_id, True)
                 HelpInfo.help_popup('suggested_lap', main_chart, arrow_pos='left_mid')
             else:
@@ -275,14 +266,13 @@ class AnalysisView(Screen):
 
     def on_add_session(self, instance, session):
         Logger.info("AnalysisView: on_add_session: {}".format(session))
-        self.check_load_suggested_lap(session.session_id)
         self.ids.sessions_view.append_session(session)
         self.check_load_suggested_lap(session.session_id)
 
     def on_delete_session(self, instance, session):
         self.ids.sessions_view.session_deleted(session)
 
-    
+
     def on_export_session(self, instance, session):
 
         def _export_session(instance):

--- a/autosportlabs/racecapture/views/analysis/analysiswidget.py
+++ b/autosportlabs/racecapture/views/analysis/analysiswidget.py
@@ -106,10 +106,12 @@ class AnalysisWidget(AnchorLayout):
 
     def _get_suggested_channels(self):
         suggested_channels = self.settings.userPrefs.get_pref_list('analysis_preferences', 'selected_analysis_channels')
+        available_channels = [c.name for c in self.datastore.channel_list]
+        suggested_channels = [c for c in suggested_channels if c in available_channels]
         if len(suggested_channels) == 0:
             suggested_channels = UserPrefs.DEFAULT_ANALYSIS_CHANNELS
         return suggested_channels
-        
+
     def _set_suggested_channels(self, channels):
         self.settings.userPrefs.set_pref_list('analysis_preferences', 'selected_analysis_channels', channels)
 

--- a/autosportlabs/racecapture/views/analysis/channelvaluesview.py
+++ b/autosportlabs/racecapture/views/analysis/channelvaluesview.py
@@ -53,7 +53,7 @@ class ChannelValueView(BoxLayout):
         try:
             value = float(value)
             self.value_view.value = value
-        except TypeError:
+        except (TypeError, ValueError):
             self.value_view.value = None
 
     @property

--- a/autosportlabs/racecapture/views/analysis/linechart.py
+++ b/autosportlabs/racecapture/views/analysis/linechart.py
@@ -487,8 +487,8 @@ class LineChart(ChannelAnalysisWidget):
         try:
             self.datastore.get_channel_data(source_ref, ['Interval', 'Distance'] + channels, get_results)
         except Exception as e:
-            alertPopup('Could not load lap', "There was a problem loading the lap due to missing data:\r\n\r\n{}".format(e))
-            raise  e# allow CrashHandler to record the issue
+            Logger.warn('Non existant channel selected, not loading channels {}; {}'.format(channels, e))
+            raise e
         finally:
             ProgressSpinner.decrement_refcount()
 

--- a/installfix_garden_graph/__init__.py
+++ b/installfix_garden_graph/__init__.py
@@ -57,8 +57,8 @@ from math import radians
 from kivy.uix.widget import Widget
 from kivy.uix.label import Label
 from kivy.uix.stencilview import StencilView
-from kivy.properties import NumericProperty, BooleanProperty,\
-    BoundedNumericProperty, StringProperty, ListProperty, ObjectProperty,\
+from kivy.properties import NumericProperty, BooleanProperty, \
+    BoundedNumericProperty, StringProperty, ListProperty, ObjectProperty, \
     DictProperty, AliasProperty
 from kivy.clock import Clock
 from kivy.graphics import Mesh, Color, Rectangle, Line
@@ -123,12 +123,12 @@ class Graph(Widget):
     _ticks_majory = ListProperty([])
     _ticks_minory = ListProperty([])
 
-    #manages the marker position on the graph
+    # manages the marker position on the graph
     marker_x = NumericProperty(None)
     '''Position of the marker, in units of % of X axis
     '''
 
-    marker_color = ListProperty([1, 1, 1 ,0.5])
+    marker_color = ListProperty([1, 1, 1 , 0.5])
     '''Color of marker; defauts to white, 50% alpha
     '''
 
@@ -283,7 +283,7 @@ class Graph(Widget):
                             points_minor[k2] = pos_log
                             k2 += 1
                     count_min += 1
-                #n_ticks = len(points)
+                # n_ticks = len(points)
             else:
                 # distance between each tick
                 tick_dist = major / float(minor if minor else 1.0)
@@ -351,7 +351,7 @@ class Graph(Widget):
             ylabels[0].texture_update()
             y1 = ylabels[0].texture_size
             y_start = y_next + (padding + y1[1] if len(xlabels) and xlabel_grid
-                                else 0) +\
+                                else 0) + \
                                 (padding + y1[1] if not y_next else 0)
             yextent = y + height - padding - y1[1] / 2.
             if self.ylog:
@@ -410,7 +410,7 @@ class Graph(Widget):
             ylabel.transform = t.multiply(
                     Matrix().translate(
                         -int(ylabel.center_x),
-                        -int(ylabel.center_y),
+                        - int(ylabel.center_y),
                         0))
         if x_overlap:
             for k in range(len(xlabels)):
@@ -645,7 +645,7 @@ class Graph(Widget):
         plot.unbind(on_clear_plot=self._clear_buffer)
         self.plots.remove(plot)
         self._clear_buffer()
-        
+
     xmin = NumericProperty(0.)
     '''The x-axis minimum value.
 
@@ -854,7 +854,7 @@ class Plot(EventDispatcher):
     ..versionadded:: 0.4
     '''
 
-    __events__ = ('on_clear_plot', )
+    __events__ = ('on_clear_plot',)
 
     # most recent values of the params used to draw the plot
     params = DictProperty({'xlog': False, 'xmin': 0, 'xmax': 100,
@@ -880,7 +880,7 @@ class Plot(EventDispatcher):
         self.ask_draw = Clock.create_trigger(self.draw)
         self.bind(params=self.ask_draw, points=self.ask_draw)
         self._drawings = self.create_drawings()
-        #plot specific y axis min/max
+        # plot specific y axis min/max
         self.ymin = None
         self.ymax = None
 
@@ -934,9 +934,14 @@ class Plot(EventDispatcher):
         ratioy = 1 if yrange == 0 else (size[3] - size[1]) / float(ymax - ymin)
         ratiox = 1 if xrange == 0 else (size[2] - size[0]) / float(xmax - xmin)
         for x, y in self.points:
+            fx = funcx(x)
+            fy = funcy(y)
+            if fy == None:
+                # if there's no Y data, give up
+                return
             yield (
-                (funcx(x) - xmin) * ratiox + size[0],
-                (funcy(y) - ymin) * ratioy + size[1])
+                (fx - xmin) * ratiox + size[0],
+                (fy - ymin) * ratioy + size[1])
 
     def on_clear_plot(self, *largs):
         pass
@@ -1037,14 +1042,14 @@ class MeshStemPlot(MeshLinePlot):
 class LinePlot(Plot):
     '''LinePlot draws using a standard Line object.
     '''
-    
+
     '''Args:
     line_width (float) - the width of the graph line
     '''
     def __init__(self, **kwargs):
         self._line_width = kwargs.get('line_width', 1)
         super(LinePlot, self).__init__(**kwargs)
-    
+
     def create_drawings(self):
         from kivy.graphics import RenderContext
 
@@ -1056,7 +1061,7 @@ class LinePlot(Plot):
             self._gline = Line(points=[], cap='none', width=self._line_width, joint='round')
 
         return [self._grc]
-    
+
     def draw(self, *args):
         super(LinePlot, self).draw(*args)
         # flatten the list
@@ -1064,7 +1069,7 @@ class LinePlot(Plot):
         for x, y in self.iterate_points():
             points += [x, y]
         self._gline.points = points
-    
+
 class SmoothLinePlot(Plot):
     '''Smooth Plot class, see module documentation for more information.
     This plot use a specific Fragment shader for a custom anti aliasing.


### PR DESCRIPTION
Various fixes to make analysis more robust:

* Better handling of cases where channels are not available in the selected session; avoid exceptions and needless error messages to the user. #1319,  #1334
* if datalog fails to import, show an error message vs. silently failing.  #1331
* Simplify, centralize and reduce code around logic that selects suggested laps
* Resolve certain cases where we try to add duplicate datapoint columns during import #1351
* Allow channel names starting with a digit. #1330 

