### PR TITLE
Allow analysis to view data when no laptiming is present. 

### DIFF
--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -1054,7 +1054,7 @@ class DataStore(object):
         :param session_id the session id
         :type session_id int
         :returns True if the session has lap information
-        :type Booolean
+        :type Boolean
         '''
         if not (self.channel_exists('CurrentLap') and self.channel_exists('LapCount')):
             return False
@@ -1063,7 +1063,7 @@ class DataStore(object):
         for row in c.execute('''SELECT s.session_id, d.LapCount, d.CurrentLap FROM sample s, 
                              datapoint d WHERE s.session_id = ? AND d.sample_id = s.id LIMIT 1;''',
                                 (session_id,)):
-            return row[1] != None and row[2] != None
+            return row[1] is not None and row[2] is not None
         return False
 
     def get_laps(self, session_id):

--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -1117,7 +1117,6 @@ class DataStore(object):
         for lap in laps:
             laps_dict[lap.lap] = lap
 
-        print('laps dict ' + str(laps_dict))
         return laps_dict
 
     def update_session(self, session):

--- a/autosportlabs/racecapture/views/analysis/analysisdata.py
+++ b/autosportlabs/racecapture/views/analysis/analysisdata.py
@@ -70,7 +70,7 @@ class CachingAnalysisDatastore(DataStore):
         Logger.info('CachingAnalysisDatastore: querying {} {}'.format(source_ref, channels))
         lap = source_ref.lap
         session = source_ref.session
-        f = Filter().eq('CurrentLap', lap)
+        f = Filter().eq('CurrentLap', lap) if self.session_has_laps(session) else None
         dataset = self.query(sessions=[session], channels=channels, data_filter=f)
         records = dataset.fetch_records()
 
@@ -187,7 +187,10 @@ class CachingAnalysisDatastore(DataStore):
         '''
         session = source_ref.session
         lap = source_ref.lap
-        f = Filter().neq('Latitude', 0).and_().neq('Longitude', 0).eq("CurrentLap", lap)
+        if self.session_has_laps(session):
+            f = Filter().neq('Latitude', 0).and_().neq('Longitude', 0).eq("CurrentLap", lap)
+        else:
+            f = Filter().neq('Latitude', 0).and_().neq('Longitude', 0)
         dataset = self.query(sessions=[session],
                                         channels=["Latitude", "Longitude"],
                                         data_filter=f)

--- a/autosportlabs/racecapture/views/analysis/analysisdata.py
+++ b/autosportlabs/racecapture/views/analysis/analysisdata.py
@@ -187,10 +187,9 @@ class CachingAnalysisDatastore(DataStore):
         '''
         session = source_ref.session
         lap = source_ref.lap
+        f = Filter().neq('Latitude', 0).and_().neq('Longitude', 0)
         if self.session_has_laps(session):
-            f = Filter().neq('Latitude', 0).and_().neq('Longitude', 0).eq("CurrentLap", lap)
-        else:
-            f = Filter().neq('Latitude', 0).and_().neq('Longitude', 0)
+            f.eq("CurrentLap", lap)
         dataset = self.query(sessions=[session],
                                         channels=["Latitude", "Longitude"],
                                         data_filter=f)

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -233,7 +233,7 @@ class AnalysisView(Screen):
     def check_load_suggested_lap(self, new_session_id):
         sessions_view = self.ids.sessions_view
         if len(sessions_view.selected_laps) == 0:
-            try:
+            if self._datastore.session_has_laps(new_session_id):
                 best_lap = self._datastore.get_channel_min('LapTime', [new_session_id], ['LapCount'])
                 best_lap_id = best_lap[1]
                 if best_lap_id:
@@ -244,7 +244,7 @@ class AnalysisView(Screen):
                 else:
                     Logger.info('AnalysisView: No best lap could be determined; selecting first lap by default for session {}'.format(new_session_id))
                     sessions_view.select_lap(new_session_id, 1, True)
-            except InvalidChannelException:  # just select the default channel
+            else:
                 sessions_view.select_lap(new_session_id, 1, True)
 
 

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -35,6 +35,7 @@ from kivy.uix.screenmanager import Screen
 from kivy.properties import ObjectProperty
 from kivy.core.window import Window
 from autosportlabs.racecapture.views.analysis.analysisdata import CachingAnalysisDatastore
+from autosportlabs.racecapture.datastore.datastore import InvalidChannelException
 from autosportlabs.racecapture.views.analysis.analysismap import AnalysisMap
 from autosportlabs.racecapture.views.analysis.channelvaluesview import ChannelValuesView
 from autosportlabs.racecapture.views.analysis.addstreamview import AddStreamView
@@ -49,7 +50,6 @@ from autosportlabs.uix.color.colorsequence import ColorSequence
 from autosportlabs.racecapture.theme.color import ColorScheme
 from autosportlabs.racecapture.settings.prefs import UserPrefs
 from autosportlabs.help.helpmanager import HelpInfo
-from autosportlabs.racecapture.views.analysis.analysisdata import CachingAnalysisDatastore
 from kivy.core.window import Window
 
 
@@ -233,16 +233,20 @@ class AnalysisView(Screen):
     def check_load_suggested_lap(self, new_session_id):
         sessions_view = self.ids.sessions_view
         if len(sessions_view.selected_laps) == 0:
-            best_lap = self._datastore.get_channel_min('LapTime', [new_session_id], ['LapCount'])
-            best_lap_id = best_lap[1]
-            if best_lap_id:
-                Logger.info('AnalysisView: Convenience selected a suggested session {} / lap {}'.format(new_session_id, best_lap_id))
-                main_chart = self.ids.mainchart
-                sessions_view.select_lap(new_session_id, best_lap_id, True)
-                HelpInfo.help_popup('suggested_lap', main_chart, arrow_pos='left_mid')
-            else:
-                Logger.info('AnalysisView: No best lap could be determined; selecting first lap by default for session {}'.format(new_session_id))
-                sessions_view.select_lap(new_session_id, 0, True)
+            try:
+                best_lap = self._datastore.get_channel_min('LapTime', [new_session_id], ['LapCount'])
+                best_lap_id = best_lap[1]
+                if best_lap_id:
+                    Logger.info('AnalysisView: Convenience selected a suggested session {} / lap {}'.format(new_session_id, best_lap_id))
+                    main_chart = self.ids.mainchart
+                    sessions_view.select_lap(new_session_id, best_lap_id, True)
+                    HelpInfo.help_popup('suggested_lap', main_chart, arrow_pos='left_mid')
+                else:
+                    Logger.info('AnalysisView: No best lap could be determined; selecting first lap by default for session {}'.format(new_session_id))
+                    sessions_view.select_lap(new_session_id, 1, True)
+            except InvalidChannelException:  # just select the default channel
+                sessions_view.select_lap(new_session_id, 1, True)
+
 
     def on_stream_connecting(self, *args):
         self.stream_connecting = True

--- a/autosportlabs/racecapture/views/analysis/linechart.py
+++ b/autosportlabs/racecapture/views/analysis/linechart.py
@@ -491,7 +491,6 @@ class LineChart(ChannelAnalysisWidget):
             self.datastore.get_channel_data(source_ref, ['Interval', 'Distance'] + channels, get_results)
         except Exception as e:
             Logger.warn('Non existant channel selected, not loading channels {}; {}'.format(channels, e))
-            raise e
         finally:
             ProgressSpinner.decrement_refcount()
 


### PR DESCRIPTION
Allows viewing of data if LapCount / CurrentLap channels are missing. 

Step to test:

* delete datastore
* disable lap timing in Setup
* write config to unit
* go to dashboard, record some data
* go to analysis, select newly recorded session for viewing

Should be able to see one 'lap' and be able to view data. 