### PR TITLE
remember track map selections. resolves #1002

### DIFF
--- a/autosportlabs/racecapture/settings/prefs.py
+++ b/autosportlabs/racecapture/settings/prefs.py
@@ -272,6 +272,15 @@ class UserPrefs(EventDispatcher):
         except Exception:
             pass
 
+    def init_pref_section(self, section):
+        '''
+        Initializes a preferences section with the specified name. 
+        if the section already exists, there is no effect. 
+        :param section the name of the preference section
+        :type string
+        '''
+        self.config.adddefaultsection(section)
+                
     def get_pref_bool(self, section, option, default=None):
         '''
         Retrieve a preferences value as a bool. 

--- a/autosportlabs/racecapture/views/analysis/analysismap.py
+++ b/autosportlabs/racecapture/views/analysis/analysismap.py
@@ -131,6 +131,7 @@ class AnalysisMap(AnalysisWidget):
     SCROLL_FACTOR = 0.15
     track_manager = ObjectProperty(None)
     datastore = ObjectProperty(None)
+    settings = ObjectProperty(None)
 
     def __init__(self, **kwargs):
         super(AnalysisMap, self).__init__(**kwargs)
@@ -146,6 +147,16 @@ class AnalysisMap(AnalysisWidget):
         Window.bind(on_motion=self.on_motion)
 
 
+    def on_settings(self, instance, value):
+        #initialize our preferences
+        value.userPrefs.init_pref_section('analysis_map')
+        
+    def get_pref_track_selections(self):
+        return self.settings.userPrefs.get_pref_list('analysis_map', 'track_selections')
+        
+    def set_pref_track_selections(self, selections):
+        self.settings.userPrefs.set_pref_list('analysis_map', 'track_selections', selections)
+        
     def refresh_view(self):
         """
         Refresh the current view
@@ -200,8 +211,27 @@ class AnalysisMap(AnalysisWidget):
             self.ids.legend_box.size_hint_x = 0.4
             self.ids.heat_channel_name.text = ''
 
-    def _update_trackmap(self, values):
-        track = self.track_manager.get_track_by_id(values.track_id)
+    def _save_selected_trackmap(self, track):
+        # save the selected track in preferences so it is remembered 
+        # for next time a track is selected in the nearby area.
+        saved_tracks = self.get_pref_track_selections()
+        
+        nearby_tracks = self.track_manager.find_nearby_tracks(track.centerpoint)
+        
+        for nearby_track in nearby_tracks:
+            if nearby_track.track_id in saved_tracks:
+                # cull any other nearby tracks; 
+                # we will replace it with our selected track
+                saved_tracks.remove(nearby_track.track_id)
+                
+        # ok, now add our selection
+        saved_tracks.append(track.track_id)
+                
+        self.set_pref_track_selections(saved_tracks)
+    
+    def _update_trackmap(self, track_id):
+        track = self.track_manager.get_track_by_id(track_id)
+        self._save_selected_trackmap(track)
         self._select_track(track)
 
     def _select_track(self, track):
@@ -214,7 +244,7 @@ class AnalysisMap(AnalysisWidget):
         self.track = track
 
     def _customized(self, instance, values):
-        self._update_trackmap(values)
+        self._update_trackmap(values.track_id)
         self._set_heat_map(values.heatmap_channel)
 
     def show_customize_dialog(self):
@@ -268,18 +298,29 @@ class AnalysisMap(AnalysisWidget):
     def select_map(self, latitude, longitude):
         """
         Find and display a nearby track by latitude / longitude
+        The selection will favor a previously selected track in the nearby area
         :param latitude
         :type  latitude float
         :param longitude
         :type longitude float
-        :returns the selected track
+        :returns the selected track, or None if there are no nearby tracks
         :type Track 
         """
+        
         if not latitude or not longitude:
             return None
+                
         point = GeoPoint.fromPoint(latitude, longitude)
-        tracks = self.track_manager.find_nearby_tracks(point)
-        track = tracks[0] if len(tracks) > 0 else None
+        nearby_tracks = self.track_manager.find_nearby_tracks(point)
+        
+        saved_tracks = self.get_pref_track_selections()
+                
+        saved_nearby_tracks = [t for t in nearby_tracks if t.track_id in saved_tracks]
+        
+        # select the saved nearby track or just a nearby track
+        track = next(iter(saved_nearby_tracks), None)
+        track = next(iter(nearby_tracks), None) if track is None else track
+                        
         if self.track != track:
             # only update the trackmap if it's changing
             self._select_track(track)

--- a/autosportlabs/racecapture/views/analysis/analysismap.py
+++ b/autosportlabs/racecapture/views/analysis/analysismap.py
@@ -218,6 +218,9 @@ class AnalysisMap(AnalysisWidget):
         
         nearby_tracks = self.track_manager.find_nearby_tracks(track.centerpoint)
         
+        # we only want one selected track map set in a nearby area'. 
+        # if we find any previously saved tracks in the list of nearby tracks,
+        # remove it.
         for nearby_track in nearby_tracks:
             if nearby_track.track_id in saved_tracks:
                 # cull any other nearby tracks; 

--- a/autosportlabs/racecapture/views/analysis/analysisview.py
+++ b/autosportlabs/racecapture/views/analysis/analysisview.py
@@ -353,6 +353,7 @@ class AnalysisView(Screen):
         channelvalues.settings = self._settings
         self.ids.analysismap.track_manager = self._track_manager
         self.ids.analysismap.datastore = self._datastore
+        self.ids.analysismap.settings = self._settings
         self.ids.sessions_view.datastore = self._datastore
         self.ids.sessions_view.settings = self._settings
         self.ids.sessions_view.init_view()

--- a/autosportlabs/racecapture/views/analysis/sessionlistview.py
+++ b/autosportlabs/racecapture/views/analysis/sessionlistview.py
@@ -248,7 +248,7 @@ class SessionListView(AnchorLayout):
         selection_json = json.dumps(selection_settings)
 
         self.settings.userPrefs.set_pref('analysis_preferences', 'selected_sessions_laps', selection_json)
-        Logger.info("SessionListView: saved selection: {}".format(selection_json))
+        Logger.debug("SessionListView: saved selection: {}".format(selection_json))
 
     @property
     def selected_count(self):


### PR DESCRIPTION
Analysis tries to automatically pick a nearby track map, but can pick the wrong one for the current data. Example; sonoma.log will pick the sonoma kart track instead of the main track. 

if you go in and override the track, and then unselect and re-select laps, then it will snap back and auto-detect the wrong track. 

The changes in this PR will remember the selected track and prefer that selection the next time it tries to auto-detect a nearby track. 

Sample logs to test with here:
https://www.dropbox.com/sh/o6u4kil4xdv4udb/AAAoOdszJSWQ9--WqUYz5zkya/sample%20logs?dl=0

Sonoma and Tsukuba logs are both good ones to test with.

Resolves #1002
