### PR TITLE
enhance usability / readability of session list

### DIFF
--- a/autosportlabs/racecapture/views/analysis/addstreamview.kv
+++ b/autosportlabs/racecapture/views/analysis/addstreamview.kv
@@ -97,37 +97,31 @@
         id: name
         size: self.texture_size
         font_size: self.height * 0.6
-        size_hint_x: 0.38
+        size_hint_x: 0.35
     FieldLabel:
         text: ''
         id: date
         size: self.texture_size
         font_size: self.height * 0.6
-        size_hint_x: 0.2
-    LabelIconButton:
-        title: 'Load'
+        size_hint_x: 0.35
+    IconButton:
         on_press: root.add_session()
-        icon: u'\uf067'
-        icon_size: self.height * .5
-        title_font_size: self.height * 0.5
+        text: u'\uf0fe'
+        font_size: self.height
         height: root.height
-        size_hint_x: 0.12
-    LabelIconButton:
-        title: 'Export'
+        size_hint_x: 0.1
+    IconButton:
         on_press: root.export_session()
-        icon: u'\uf045'
-        icon_size: self.height * .5
-        title_font_size: self.height * 0.5
+        text: u'\uf045'
+        font_size: self.height
         height: root.height
-        size_hint_x: 0.15
-    LabelIconButton:
-        title: 'Delete'
+        size_hint_x: 0.1
+    IconButton:
         on_press: root.delete_session()
-        icon: u'\uf014'
-        icon_size: self.height * .5
-        title_font_size: self.height * 0.5
+        text: u'\uf014'
+        font_size: self.height
         height: root.height
-        size_hint_x: 0.15
+        size_hint_x: 0.1
 
 <FileConnectView>:
     BoxLayout:

--- a/autosportlabs/racecapture/views/analysis/addstreamview.kv
+++ b/autosportlabs/racecapture/views/analysis/addstreamview.kv
@@ -92,36 +92,39 @@
 <SessionListItem>:
     rows: 1
     spacing: dp(10)
-    FieldLabel:
-        text: ''
-        id: name
-        size: self.texture_size
-        font_size: self.height * 0.6
-        size_hint_x: 0.35
-    FieldLabel:
-        text: ''
-        id: date
-        size: self.texture_size
-        font_size: self.height * 0.6
-        size_hint_x: 0.35
+    BoxLayout:
+        orientation: 'horizontal'
+        FieldLabel:
+            text: ''
+            id: name
+#            size: self.texture_size
+            font_size: self.height * 0.6
+        FieldLabel:
+            text: ''
+            id: date
+ #           size: self.texture_size
+            font_size: self.height * 0.6
     IconButton:
         on_press: root.add_session()
         text: u'\uf0fe'
         font_size: self.height
         height: root.height
-        size_hint_x: 0.1
+        width: dp(50)
+        size_hint_x: None
     IconButton:
         on_press: root.export_session()
         text: u'\uf045'
         font_size: self.height
         height: root.height
-        size_hint_x: 0.1
+        width: dp(50)
+        size_hint_x: None
     IconButton:
         on_press: root.delete_session()
         text: u'\uf014'
         font_size: self.height
         height: root.height
-        size_hint_x: 0.1
+        width: dp(50)
+        size_hint_x: None
 
 <FileConnectView>:
     BoxLayout:

--- a/autosportlabs/racecapture/views/analysis/addstreamview.kv
+++ b/autosportlabs/racecapture/views/analysis/addstreamview.kv
@@ -97,12 +97,10 @@
         FieldLabel:
             text: ''
             id: name
-#            size: self.texture_size
             font_size: self.height * 0.6
         FieldLabel:
             text: ''
             id: date
- #           size: self.texture_size
             font_size: self.height * 0.6
     IconButton:
         on_press: root.add_session()

--- a/autosportlabs/racecapture/views/analysis/addstreamview.py
+++ b/autosportlabs/racecapture/views/analysis/addstreamview.py
@@ -42,7 +42,7 @@ from autosportlabs.uix.textwidget import FieldInput
 from autosportlabs.racecapture.views.util.alertview import alertPopup, confirmPopup
 from autosportlabs.racecapture.views.file.loaddialogview import LoadDialog
 from autosportlabs.racecapture.views.file.savedialogview import SaveDialog
-from autosportlabs.util.timeutil import format_time
+from autosportlabs.util.timeutil import friendly_format_time_ago
 from iconbutton import IconButton
 from fieldlabel import FieldLabel
 from iconbutton import LabelIconButton
@@ -196,7 +196,7 @@ class SessionImportView(BaseStreamConnectView):
         for session in sessions:
             session_view = SessionListItem(session)
             session_view.ids.name.text = session.name
-            session_view.ids.date.text = format_time(datetime.fromtimestamp(session.date))
+            session_view.ids.date.text = friendly_format_time_ago(datetime.utcfromtimestamp(session.date))
             session_view.bind(on_delete=self.delete_session)
             session_view.bind(on_add=self.add_session)
             session_view.bind(on_export=self.export_session)

--- a/autosportlabs/util/timeutil.py
+++ b/autosportlabs/util/timeutil.py
@@ -18,7 +18,7 @@
 # have received a copy of the GNU General Public License along with
 # this code. If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ('time_to_epoch', 'format_time', 'format_date', 'epoch_to_time')
+__all__ = ('time_to_epoch', 'format_time', 'friendly_format_time_ago', 'format_date', 'epoch_to_time')
 import calendar
 from datetime import datetime
 from kivy import platform
@@ -51,6 +51,36 @@ def time_to_epoch(timestamp):
 
     return int(calendar.timegm(t.timetuple()))
 
+def friendly_format_time_ago(dt):
+    """
+    Format the specified time relative to now in 
+    a friendly readable format.
+    If the specified time was less than a minute ago, it will report 'Just now'. 
+    If less than an hour, it will report 'X min ago'. 
+    If less than a day, it will report 'X hour Y min ago'.
+    """
+    
+    def _plural(val):
+        return 's' if val > 1 else ''
+    
+    n = datetime.now()
+    diff = n - dt
+    sec = int(diff.total_seconds())
+    if sec < 60:
+        return 'Just now'
+    
+    minutes = sec / 60
+    if minutes < 60:
+        return '{} min{} ago'.format(minutes, _plural(minutes))
+    
+    hours = minutes / 60
+    if hours < 24:
+        minutes %= 60
+        return '{} hour{} {} min{} ago'.format(hours, _plural(hours), minutes, _plural(minutes))
+    
+    # too long ago, just return the date
+    return format_time(dt)
+    
 def format_time(dt=datetime.now()):
     """
     format the supplied datetime to the current locale

--- a/test/autosportlabs/util/test_timeutil.py
+++ b/test/autosportlabs/util/test_timeutil.py
@@ -19,6 +19,7 @@
 # this code. If not, see <http://www.gnu.org/licenses/>.
 import unittest
 from autosportlabs.util.timeutil import *
+from datetime import datetime, timedelta
 
 class TimeUtilTest(unittest.TestCase):
 
@@ -30,6 +31,16 @@ class TimeUtilTest(unittest.TestCase):
 
         self.assertTrue(t1 == t2 == t3 == t4)
 
+    def test_friendly_format_time_ago(self):
+        n = datetime.now()
+        self.assertEqual('Just now', friendly_format_time_ago(n - timedelta(seconds=1))) 
+        self.assertEqual('1 min ago', friendly_format_time_ago(n - timedelta(minutes=1)))
+        self.assertEqual('2 mins ago', friendly_format_time_ago(n - timedelta(minutes=2)))
+        self.assertEqual('1 hour 1 min ago', friendly_format_time_ago(n - timedelta(minutes=61)))
+        self.assertEqual('2 hours 2 mins ago', friendly_format_time_ago(n - timedelta(minutes=122)))
+        long_ago = n - timedelta(days=30)
+        self.assertEqual(format_time(long_ago), friendly_format_time_ago(long_ago))
+        
 def main():
     unittest.main()
 


### PR DESCRIPTION
Resolves the issue of frequent truncation of session name and date time, while making the listing more readable through friendlier descriptions of date time stamps. 

New dialog looks like this:

![image](https://cloud.githubusercontent.com/assets/3267533/26766980/d60a0d86-494f-11e7-9fad-92b796e0b55e.png)

resolves #1375 #1336 #1092 