### PR TITLE
Session record opt

### DIFF
--- a/autosportlabs/racecapture/data/sessionrecorder.py
+++ b/autosportlabs/racecapture/data/sessionrecorder.py
@@ -229,7 +229,9 @@ class SessionRecorder(EventDispatcher):
                     self._datastore.insert_sample_nocommit(
                         sample_data, self._current_session_id)
                     qsize = sample_queue.qsize()
-                    if qsize == 0:
+                    if (qsize == 0) or (index % 20 == 0):
+                        # since the commit is slow, only do the commit once the queue empty to prevent overrunning the buffer.
+                        # the % 20 ensures that commit is called occasionally if this loop isn't keeping up with the "producer"
                         self._datastore.commit()
                     elif index % SessionRecorder.SAMPLE_QUEUE_BACKLOG_LOG_INTERVAL == 0:
                         Logger.info(

--- a/autosportlabs/racecapture/data/sessionrecorder.py
+++ b/autosportlabs/racecapture/data/sessionrecorder.py
@@ -40,7 +40,7 @@ class SessionRecorder(EventDispatcher):
     # displayed
     RECORDING_VIEWS = ['dash']
     SAMPLE_QUEUE_GET_TIMEOUT = 0.5
-    SAMPLE_QUEUE_MAX_SIZE = 500
+    SAMPLE_QUEUE_MAX_SIZE = 20
     SAMPLE_QUEUE_BACKLOG_LOG_INTERVAL = 100
 
     def __init__(self, datastore, databus, rcpapi, settings, track_manager=None, status_pump=None, stop_delay=120):

--- a/autosportlabs/racecapture/data/sessionrecorder.py
+++ b/autosportlabs/racecapture/data/sessionrecorder.py
@@ -226,10 +226,12 @@ class SessionRecorder(EventDispatcher):
                     # Merging previous sample with new data to desparsify the
                     # data
                     sample_data.update(sample)
-                    self._datastore.insert_sample(
+                    self._datastore.insert_sample_nocommit(
                         sample_data, self._current_session_id)
                     qsize = sample_queue.qsize()
-                    if index % SessionRecorder.SAMPLE_QUEUE_BACKLOG_LOG_INTERVAL == 0 and qsize > 0:
+                    if qsize == 0:
+                        self._datastore.commit()
+                    elif index % SessionRecorder.SAMPLE_QUEUE_BACKLOG_LOG_INTERVAL == 0:
                         Logger.info(
                             'SessionRecorder: queue backlog: {}'.format(qsize))
                     index += 1

--- a/autosportlabs/racecapture/data/sessionrecorder.py
+++ b/autosportlabs/racecapture/data/sessionrecorder.py
@@ -124,6 +124,7 @@ class SessionRecorder(EventDispatcher):
                 self._create_session_name(), self._channels)
             self.dispatch('on_recording', True)
             self.recording = True
+            self._sample_accumulator = {}
 
             t = Thread(target=self._session_recorder_worker)
             t.daemon = True
@@ -240,9 +241,8 @@ class SessionRecorder(EventDispatcher):
                         insert_counter = 0
                     
                     if qsize > 0 and index % SessionRecorder.SAMPLE_QUEUE_BACKLOG_LOG_INTERVAL == 0:
-                        Logger.info( 'SessionRecorder: queue backlog: {}'.format(qsize))
-                        Logger.info( 'SessionRecorder: commit backlog: {}'.format(insert_counter))
-                        Logger.info( 'SessionRecorder: sample send delay: {}ms'.format(self._sample_send_delay))
+                        Logger.info( 'SessionRecorder: queue backlog: {}, commit backlog: {}, sample send delay: {}ms'
+				.format(qsize, insert_counter, self._sample_send_delay ))
 
                     if insert_counter > (SessionRecorder.SAMPLE_QUEUE_UNCOMMITTED_INSERT_LIMIT*SessionRecorder.SAMPLE_QUEUE_BACKLOG_LOG_THRESHOLD):
                         Logger.debug( 'SessionRecorder: commit backlog: {}'.format(insert_counter))

--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -559,6 +559,9 @@ class DataStore(object):
             raise
 
     def commit(self):
+        """
+        Commit any pending changes to the database.
+        """
         try:
             self._conn.commit()
         except:  # rollback under any exception, then re-raise exception
@@ -566,6 +569,10 @@ class DataStore(object):
             raise
 
     def insert_sample_nocommit(self, sample, session_id):
+        """
+        Insert samples which are queued to be added to the DB. 
+        A subsequent commit is required before the sample will appear in the DB.
+        """
         cursor = self._conn.cursor()
         try:
             # First, insert into the datalog table to give us a reference
@@ -586,7 +593,7 @@ class DataStore(object):
                                                                        ','.join(['?'] * (len(values))))
 
             cursor.execute(base_sql, values)
-            # self._conn.commit() # moved to separate function
+
         except:  # rollback under any exception, then re-raise exception
             self._conn.rollback()
             raise

--- a/autosportlabs/racecapture/datastore/datastore.py
+++ b/autosportlabs/racecapture/datastore/datastore.py
@@ -558,7 +558,14 @@ class DataStore(object):
             self._conn.rollback()
             raise
 
-    def insert_sample(self, sample, session_id):
+    def commit(self):
+        try:
+            self._conn.commit()
+        except:  # rollback under any exception, then re-raise exception
+            self._conn.rollback()
+            raise
+
+    def insert_sample_nocommit(self, sample, session_id):
         cursor = self._conn.cursor()
         try:
             # First, insert into the datalog table to give us a reference
@@ -579,7 +586,7 @@ class DataStore(object):
                                                                        ','.join(['?'] * (len(values))))
 
             cursor.execute(base_sql, values)
-            self._conn.commit()
+            # self._conn.commit() # moved to separate function
         except:  # rollback under any exception, then re-raise exception
             self._conn.rollback()
             raise

--- a/test/autosportlabs/racecapture/data/test_sessionrecorder.py
+++ b/test/autosportlabs/racecapture/data/test_sessionrecorder.py
@@ -21,7 +21,7 @@
 import unittest
 from mock import Mock, patch
 from autosportlabs.racecapture.data.sessionrecorder import SessionRecorder
-
+import Queue
 
 class TestSessionRecorder(unittest.TestCase):
 
@@ -158,6 +158,40 @@ class TestSessionRecorder(unittest.TestCase):
         disconnect_listener()
         self.assertFalse(session_recorder.recording, "Session recorder stops recording on disconnect")
 
+    def test_on_sample(self):
+        # warning: this is test is  necessarily slow, as it involves timing the queue performance.
+        session_recorder = SessionRecorder(self.mock_datastore, self.mock_databus, self.mock_rcp_api,
+                                           self.mock_settings, self.mock_track_manager, self.mock_status_pump)
+        
+	q = session_recorder._sample_queue
+        session_recorder.recording = True
+
+	sampleIn = { 'v': 0 }
+	session_recorder._on_sample( sampleIn )
+	sampleOut = q.get( True, 0 )
+        self.assertTrue(sampleIn == sampleOut, "Session recorder basic queue test")
+
+	i = 0
+        while not session_recorder._sample_queue_full:
+            session_recorder._on_sample( { 'v': i } )
+            i += 1
+
+        self.assertTrue( session_recorder._sample_send_delay
+            == SessionRecorder.SAMPLE_QUEUE_MAX_SEND_DELAY_MS,
+                "Session recorder is slowing sample rate" )
+        
+        for i in range( 0, SessionRecorder.SAMPLE_QUEUE_MAX_SIZE * 2 ):
+            session_recorder._on_sample( { 'v': i } )
+            try:
+                sampleOut = q.get( True, 0 )
+                sampleOut = q.get( True, 0 )
+            except Queue.Empty:
+                pass
+
+        self.assertTrue( session_recorder._sample_send_delay
+            == SessionRecorder.SAMPLE_QUEUE_MIN_SEND_DELAY_MS,
+                "Session recorder is restoring max sample rate" )
+        
 
 def main():
     unittest.main()


### PR DESCRIPTION
I've separated the sqlite.commit call from the DataStore.insert_sample.  I don't think it's being used elsewhere, but I renamed it to insert_sample_nocommit, just in case it's being used elsewhere - it should get caught early.  Any calls to insert_sample should be followed by a call to commit.

I only execute the (new) DataStore.commit()  in the _session_recorder_worker function once the queue is empty.  On my computer that was constantly fill the queue of 500, it now executes the commit for every two insert_sample calls (very occasionally it gets to 5).  I have not observed a backlog of more than 5 post-change.

I've reduced the queue size to 20.  This seems to be sufficient to avoid dropping samples (on the one machine I've tested on).
 #1481 