### PR TITLE
Add sub ID support to CAN mapping

### DIFF
--- a/autosportlabs/racecapture/config/rcpconfig.py
+++ b/autosportlabs/racecapture/config/rcpconfig.py
@@ -844,12 +844,14 @@ class CANMapping(object):
     CAN_MAPPING_TYPE_SIGN_MAGNITUDE = 3
     ID_MASK_DISABLED = 0
     CONVERSION_FILTER_DISABLED = 0
+    SUB_ID_DISABLED = -1
 
     def __init__(self, **kwargs):
         self.bit_mode = False
         self.type = CANMapping.CAN_MAPPING_TYPE_UNSIGNED
         self.can_bus = 0
         self.can_id = 0
+        self.sub_id = CANMapping.SUB_ID_DISABLED
         self.can_mask = CANMapping.ID_MASK_DISABLED
         self.endian = False
         self.offset = 0
@@ -865,6 +867,7 @@ class CANMapping(object):
             self.type = json_dict.get('type', self.type)
             self.can_bus = json_dict.get('bus', self.can_bus)
             self.can_id = json_dict.get('id', self.can_id)
+            self.sub_id = json_dict.get('subId', self.sub_id)
             self.can_mask = json_dict.get('idMask', self.can_mask)
             self.offset = json_dict.get('offset', self.offset)
             self.length = json_dict.get('len', self.length)
@@ -881,6 +884,7 @@ class CANMapping(object):
         json_dict['type'] = self.type
         json_dict['bus'] = self.can_bus
         json_dict['id'] = self.can_id
+        json_dict['subId'] = self.sub_id
         json_dict['idMask'] = self.can_mask
         json_dict['offset'] = self.offset
         json_dict['len'] = self.length

--- a/autosportlabs/racecapture/views/configuration/rcp/canmappingview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/canmappingview.py
@@ -204,16 +204,28 @@ class CANIDMappingTab(CANChannelMappingTab):
                             
             AnchorLayout:
                 size_hint_x: 0.45
-                SectionBoxLayout:
-                    size_hint_y: 0.5
-                    FieldLabel:
-                        text: 'CAN Bus'
-                        halign: 'right'
-                        size_hint_x: 0.55
-                    LargeMappedSpinner:
-                        id: can_bus_channel
-                        size_hint_x: 0.45
-                        on_text: root._on_can_bus(*args)
+                BoxLayout:
+                    size_hint_y: 0.8
+                    orientation: 'vertical'
+                    spacing: dp(5)
+                    SectionBoxLayout:
+                        FieldLabel:
+                            text: 'Sub ID'
+                            halign: 'right'
+                            size_hint_x: 0.45
+                        LargeMappedSpinner:
+                            id: sub_id
+                            size_hint_x: 0.55
+                            on_text: root._on_sub_id(*args)
+                    SectionBoxLayout:
+                        FieldLabel:
+                            text: 'CAN Bus'
+                            halign: 'right'
+                            size_hint_x: 0.45
+                        LargeMappedSpinner:
+                            id: can_bus_channel
+                            size_hint_x: 0.55
+                            on_text: root._on_can_bus(*args)
                 
 """)
 
@@ -225,13 +237,18 @@ class CANIDMappingTab(CANChannelMappingTab):
         self._loaded = False
         self.channel_cfg = channel_cfg
         self.ids.can_bus_channel.setValueMap({0: '1', 1: '2'}, '1')
-
+                
+        self.ids.sub_id.setValueMap({i:'Disabled' if i < 0 else str(i) for i in range(-1,20)}, 
+                                    'Disabled')
         # CAN bus
         self.ids.can_bus_channel.setFromValue(self.channel_cfg.mapping.can_bus)
 
         # CAN ID
         self.ids.can_id.text = str(self.channel_cfg.mapping.can_id)
 
+        # CAN Sub ID
+        self.ids.sub_id.setFromValue(self.channel_cfg.mapping.sub_id)
+        
         # CAN mask
         self.ids.mask.text = str(self.channel_cfg.mapping.can_mask)
         self._loaded = True
@@ -244,6 +261,10 @@ class CANIDMappingTab(CANChannelMappingTab):
         if self._loaded:
             self.channel_cfg.mapping.can_id = int(value)
 
+    def _on_sub_id(self, instance, value):
+        if self._loaded:
+            self.channel_cfg.mapping.sub_id = instance.getValueFromKey(value)
+            
     def _on_mask(self, instance, value):
         if self._loaded:
             self.channel_cfg.mapping.can_mask = int(value)


### PR DESCRIPTION
For certain CAN integrations, such as SmartyCAM GPS data, we need to match on the CAN ID as well as a sub ID in the first data byte. This extends the API and CAN mapping UI view to meet this requirement.

resolves #1514  

Corresponding firmware PR: https://github.com/autosportlabs/RaceCapture-Pro_firmware/pull/965