### PR TITLE
extend dynamic range of smoothing. resolves #1571

### DIFF
--- a/autosportlabs/racecapture/views/configuration/rcp/analogchannelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/analogchannelsview.py
@@ -62,6 +62,11 @@ class AnalogChannelsView(BaseMultiChannelConfigView):
         return rcp_cfg.analogConfig
 
 class AnalogChannel(BaseChannelView):
+    MIN_SMOOTHING_RANGE = 0
+    MAX_SMOOTHING_RANGE = 1000000
+    ALPHA_SMOOTHING_FACTOR = 0.0000001
+    DISPLAY_SCALING = 0.01
+
     Builder.load_string("""
 <AnalogChannel>:
     orientation: 'horizontal'
@@ -125,8 +130,8 @@ class AnalogChannel(BaseChannelView):
                         halign: 'right'
                     Slider:
                         id: smoothing
-                        min: 0
-                        max: 100
+                        min: root.MIN_SMOOTHING_RANGE
+                        max: root.MAX_SMOOTHING_RANGE
                         on_value: root.on_smoothing(*args)
                     FieldLabel:
                         text: 'More'
@@ -220,15 +225,21 @@ class AnalogChannel(BaseChannelView):
         self.channelConfig = None
 
     def on_smoothing(self, instance, value):
-        self.ids.smoothing_value.text = 'Max' if value > 99 else str(int(value))
-        try:
-            if self.channelConfig:
-                alpha = max(0.005, (100.0 - float(value)) * .01)
-                self.channelConfig.alpha = alpha
-                self.channelConfig.stale = True
-                self.dispatch('on_modified', self.channelConfig)
-        except:
-            pass
+        label = ''
+        if value == AnalogChannel.MIN_SMOOTHING_RANGE:
+            label = 'Min'
+        elif value == AnalogChannel.MAX_SMOOTHING_RANGE:
+            label = 'Max'
+        else:
+            label = str(int(value / (AnalogChannel.MAX_SMOOTHING_RANGE * AnalogChannel.DISPLAY_SCALING)))
+
+        self.ids.smoothing_value.text = label
+        if self.channelConfig:
+            alpha = 1.0 if value == 0 else (AnalogChannel.MAX_SMOOTHING_RANGE - float(value)) * AnalogChannel.ALPHA_SMOOTHING_FACTOR
+
+            self.channelConfig.alpha = alpha
+            self.channelConfig.stale = True
+            self.dispatch('on_modified', self.channelConfig)
 
     def on_linear_map_offset(self, instance, value):
         try:
@@ -295,7 +306,7 @@ class AnalogChannel(BaseChannelView):
             check_linear.active = False
             check_mapped.active = True
 
-        self.ids.smoothing.value = round(100 - (channelConfig.alpha * 100.0))
+        self.ids.smoothing.value = AnalogChannel.MAX_SMOOTHING_RANGE - (channelConfig.alpha / AnalogChannel.ALPHA_SMOOTHING_FACTOR)
         self.ids.linearscaling.text = str(channelConfig.linearScaling)
         self.ids.linearoffset.text = str(channelConfig.linearOffset)
         map_editor = self.ids.map_editor

--- a/autosportlabs/racecapture/views/configuration/rcp/analogchannelsview.py
+++ b/autosportlabs/racecapture/views/configuration/rcp/analogchannelsview.py
@@ -66,6 +66,7 @@ class AnalogChannel(BaseChannelView):
     MAX_SMOOTHING_RANGE = 1000000
     ALPHA_SMOOTHING_FACTOR = 0.0000001
     DISPLAY_SCALING = 0.01
+    MIN_SMOOTHING = 1.0
 
     Builder.load_string("""
 <AnalogChannel>:
@@ -306,7 +307,7 @@ class AnalogChannel(BaseChannelView):
             check_linear.active = False
             check_mapped.active = True
 
-        self.ids.smoothing.value = AnalogChannel.MAX_SMOOTHING_RANGE - (channelConfig.alpha / AnalogChannel.ALPHA_SMOOTHING_FACTOR)
+        self.ids.smoothing.value = 0 if channelConfig.alpha == AnalogChannel.MIN_SMOOTHING else AnalogChannel.MAX_SMOOTHING_RANGE - (channelConfig.alpha / AnalogChannel.ALPHA_SMOOTHING_FACTOR)
         self.ids.linearscaling.text = str(channelConfig.linearScaling)
         self.ids.linearoffset.text = str(channelConfig.linearOffset)
         map_editor = self.ids.map_editor


### PR DESCRIPTION
Resolves #1571 ; 

Extend dynamic range of smoothing to provide a min smoothing value between 1.0 (no smoothing) and 0 (max smoothing as defined by firmware). Tune the range so that 50% smoothing has an alpha of .05

related firmware issue: https://github.com/autosportlabs/RaceCapture-Pro_firmware/issues/999