### PR TITLE
basic zerorpc integration for getting channel info

### DIFF
--- a/autosportlabs/racecapture/api/rcprpc.py
+++ b/autosportlabs/racecapture/api/rcprpc.py
@@ -1,0 +1,38 @@
+#
+# Race Capture App
+#
+# Copyright (C) 2014-2017 Autosport Labs
+#
+# This file is part of the Race Capture App
+#
+# This is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See the GNU General Public License for more details. You should
+# have received a copy of the GNU General Public License along with
+# this code. If not, see <http://www.gnu.org/licenses/>.
+
+class RaceCaptureRPC(object):
+    def __init__(self, app):
+        self.app = app
+
+    def list_active_channels(self):
+        return [c.name for name, c in self.app.settings.runtimeChannels.get_active_channels().items()]
+
+    def get_active_channels(self):
+        return [c.toJson() for name, c in self.app.settings.runtimeChannels.get_active_channels().items()]
+
+    def get_channel_meta(self, channel):
+        return self.app.settings.runtimeChannels.findChannelMeta(channel).toJson()
+
+    def get_channel_value(self, channel):
+        return self.app.settings.runtimeChannels.data_bus.getData(channel)
+
+    def get_channel_values(self):
+        return self.app.settings.runtimeChannels.data_bus.channel_data

--- a/autosportlabs/racecapture/data/channels.py
+++ b/autosportlabs/racecapture/data/channels.py
@@ -66,6 +66,22 @@ class ChannelMeta(object):
         self.sampleRate = int(json.get('sr', self.sampleRate))
         self.type = int(json.get('type', self.type))
 
+    def toJson(self):
+        return unicode(json.dumps(
+            {
+                'name': self.name,
+                'units': self.units,
+                'min': self.min,
+                'max': self.max,
+                'precision': self.precision,
+                'sampleRate': self.sampleRate,
+                'type': self.type
+            }
+        ))
+
+    def __unicode__(self):
+        return self.name
+
 
 class ChannelMetaCollection(object):
     channel_metas = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pygments==2.0.2
 mock==1.3.0
 raven==5.5.0
 sqlalchemy==1.1.3
+zerorpc==0.6.1


### PR DESCRIPTION
Very, very basic pull to start a zerorpc server on a thread and provide RPC methods
to list and get channel meta info and values. No attempt at providing streaming here
since from what I'm reading streaming an undefined amount of data isn't really what
zerorpc is trying to accomplish with its "stream" (more like chunked responses).

Some examples...

Listing active channels:
```
$ zerorpc tcp://127.0.0.1:4242 list_active_channels
connecting to "tcp://127.0.0.1:4242"
['GPSQual',
 'Utc',
 'Yaw',
 'GPSSats',
 'CurrentLap',
 'OilPress',
 'Latitude',
 'LapDelta',
 'Roll',
 'GPIO2',
 'GPIO3',
 'BestLap',
 'GPIO1',
 'AccelZ',
 'OilTemp',
 'AccelX',
 'AccelY',
 'GPSDOP',
 'RPM',
 'Altitude',
 'Distance',
 'EngineTemp',
 'Interval',
 'Longitude',
 'ElapsedTime',
 'TPS',
 'PredTime',
 'SectorTime',
 'Gear',
 'Sector',
 'Battery',
 'LapCount',
 'LapTime',
 'Pitch',
 'Speed']
```

Getting meta info about active channels:
```
$ zerorpc tcp://127.0.0.1:4242 get_active_channels
connecting to "tcp://127.0.0.1:4242"
['{"name": "GPSQual", "min": 0, "max": 5, "precision": 0, "units": "", '
 '"sampleRate": 10, "type": 0}',
 '{"name": "Utc", "min": 0, "max": 0, "precision": 0, "units": "ms", '
 '"sampleRate": 1, "type": 0}',
 '{"name": "Yaw", "min": -120, "max": 120, "precision": 0, "units": "Deg/Sec", '
 '"sampleRate": 25, "type": 0}',
 '{"name": "GPSSats", "min": 0, "max": 20, "precision": 0, "units": "", '
 '"sampleRate": 10, "type": 0}',
 '{"name": "CurrentLap", "min": 0, "max": 0, "precision": 0, "units": "", '
 '"sampleRate": 10, "type": 0}',
 '{"name": "OilPress", "min": 0, "max": 150, "precision": 0, "units": "PSI", '
 '"sampleRate": 10, "type": 0}',
 '{"name": "Latitude", "min": -180.0, "max": 180.0, "precision": 6, "units": '
 '"Degrees", "sampleRate": 10, "type": 0}',
 '{"name": "LapDelta", "min": 0, "max": 0, "precision": 1, "units": "Min", '
 '"sampleRate": 1, "type": 5}',
...
```

Getting a single channel current value:
```
$ zerorpc tcp://127.0.0.1:4242 get_channel_value Interval
connecting to "tcp://127.0.0.1:4242"
251582.0
```

Getting all current channel values:
```
$ zerorpc tcp://127.0.0.1:4242 get_channel_values
connecting to "tcp://127.0.0.1:4242"
{'AccelX': -0.0,
 'AccelY': -0.93,
 'AccelZ': 1.54,
 'Altitude': 0.0,
 'Battery': 5.03,
 'CurrentLap': 0.0,
 'Distance': 0.0,
 'ElapsedTime': 0.0,
 'EngineTemp': 0.0,
 'GPIO1': 0.0,
 'GPIO2': 0.0,
 'GPIO3': 0.0,
 'GPSDOP': 0.0,
 'GPSQual': 0.0,
 'GPSSats': 0.0,
 'Gear': 0.0,
 'Interval': 263582.0,
 'LapCount': 0.0,
 'LapTime': 0.0,
 'Latitude': 0.0,
 'Longitude': 0.0,
 'OilPress': 0.0,
 'OilTemp': 302.0,
 'Pitch': 0.0,
 'PredTime': 0.0,
 'RPM': 0.0,
 'Roll': 0.0,
 'Sector': -1.0,
 'SectorTime': 0.0,
 'Speed': 0.0,
 'TPS': 0.0,
 'Utc': 0.0,
 'Yaw': 1.0}
```